### PR TITLE
Cmake: Fix order of SYSTEM and PUBLIC headers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -123,13 +123,10 @@ add_library(${PROJECT_NAME} STATIC
 
 set_property(TARGET ${PROJECT_NAME} PROPERTY POSITION_INDEPENDENT_CODE ON)
 
-# this is needed for the #include directives with absolutes paths to work correctly; it must
-# also be set to PUBLIC since sub-tools of remill include remill's headers directly.
-list(APPEND PROJECT_INCLUDEDIRECTORIES ${CMAKE_SOURCE_DIR})
-
 # add everything as public.
 target_link_libraries(${PROJECT_NAME} PUBLIC ${PROJECT_LIBRARIES})
-target_include_directories(${PROJECT_NAME} PUBLIC SYSTEM ${PROJECT_INCLUDEDIRECTORIES})
+target_include_directories(${PROJECT_NAME} PUBLIC ${CMAKE_SOURCE_DIR})
+target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC ${PROJECT_INCLUDEDIRECTORIES})
 target_compile_definitions(${PROJECT_NAME} PUBLIC ${PROJECT_DEFINITIONS} ${GLOBAL_DEFINITIONS})
 target_compile_options(${PROJECT_NAME} PUBLIC ${GLOBAL_CXXFLAGS})
 


### PR DESCRIPTION
This PR changes the `include_directories` used by remill by while compiling:
* Fix the order of the `SYSTEM` and `PUBLIC` keywords so that they appear in the same order as in the [CMake documentation](https://cmake.org/cmake/help/v3.2/command/target_include_directories.html). The previous order would result in `SYSTEM` being erroneously prefixed to the include paths.
* Don't mark local remill headers as SYSTEM. This gives the remill headers that are local to the current build directory the priority compared to possibly previously installed remill headers, allowing to compile a local version more recent than the installed version.

Tests:
* Run `make VERBOSE=true` on `master`, you can see that `SYSTEM` is being prefixed to some paths that appear in `-I` arguments. With this PR, it doesn't happen anymore.
* From a build directory, make and make install remill. Then, modify the headers in the *installation directory* (for instance by deleting a class, simulating a breaking change from a future version). Then, try to make again. On `master`, this fails because the *installed* headers are selected before the headers local to the build directory. With this PR, this succeeds because the installed headers are still considered as "SYSTEM", and the local headers are not anymore. 