### PR TITLE
Fix x86-64 Instruction Semantics

### DIFF
--- a/remill/Arch/X86/Semantics/LOGICAL.cpp
+++ b/remill/Arch/X86/Semantics/LOGICAL.cpp
@@ -168,13 +168,13 @@ DEF_SEM(PAND, D dst, S1 src1, S2 src2) {
 
 template <typename D, typename S1, typename S2>
 DEF_SEM(PANDN_64, D dst, S1 src1, S2 src2) {
-  UWriteV64(dst, UAndNV64(UReadV64(src1), UReadV64(src2)));
+  UWriteV64(dst, UAndNV64(UReadV64(src2), UReadV64(src1)));
   return memory;
 }
 
 template <typename D, typename S1, typename S2>
 DEF_SEM(PANDN, D dst, S1 src1, S2 src2) {
-  UWriteV32(dst, UAndNV32(UReadV32(src1), UReadV32(src2)));
+  UWriteV32(dst, UAndNV32(UReadV32(src2), UReadV32(src1)));
   return memory;
 }
 

--- a/remill/Arch/X86/Semantics/MMX.cpp
+++ b/remill/Arch/X86/Semantics/MMX.cpp
@@ -1845,10 +1845,16 @@ DEF_SEM(PMULUDQ, D dst, S1 src1, S2 src2) {
   auto src1_vec = UReadV32(src1);
   auto src2_vec = UReadV32(src2);
   auto dst_vec = UClearV64(UReadV64(dst));
-  auto v1 = ZExt(UExtractV32(src1_vec, 0));
-  auto v2 = ZExt(UExtractV32(src2_vec, 0));
-  auto mul = UMul(v1, v2);
-  UWriteV64(dst, UInsertV64(dst_vec, 0, mul));
+
+  auto vec_count = NumVectorElems(src1_vec);
+  _Pragma("unroll")
+  for (size_t i = 0; i < vec_count/2; i++) {
+    auto v1 = ZExt(UExtractV32(src1_vec, i*2));
+    auto v2 = ZExt(UExtractV32(src2_vec, i*2));
+    auto mul = UMul(v1, v2);
+    dst_vec = UInsertV64(dst_vec, i, mul);
+  }
+  UWriteV64(dst, dst_vec);
   return memory;
 }
 

--- a/remill/Arch/X86/Semantics/SEMAPHORE.cpp
+++ b/remill/Arch/X86/Semantics/SEMAPHORE.cpp
@@ -100,11 +100,11 @@ DEF_SEM(XADD, D1 dst1, S1 src1, D2 dst2, S2 src2) {
     BarrierStoreLoad();
   }
 
-  auto rhs = Read(src2);
-  auto lhs = UFetchAdd(dst1, rhs);
-  auto sum = UAdd(lhs, rhs);
+  auto rhs = Read(src1);
+  auto lhs = Read(src2);
+  auto sum = UAddFetch(dst2, rhs);
   WriteFlagsAddSub<tag_add>(state, rhs, lhs, sum);
-  WriteZExt(dst2, lhs);
+  WriteZExt(dst1, sum);
   return memory;
 }
 


### PR DESCRIPTION
It fixes the `xadd`, `andnp`, `pmulud` and `cmpxchg` set of instructions semantics. 

It does not handle the issue associated with `cmpxchgb %ah, %al` where the bits of`EAX` does not get updated. The semantic looks correct but the issue occurs after optimization. 