### PR TITLE
Util improvement

### DIFF
--- a/remill/BC/Util.cpp
+++ b/remill/BC/Util.cpp
@@ -103,19 +103,8 @@ llvm::CallInst *AddTerminatingTailCall(llvm::Function *source_func,
   if (source_func->isDeclaration()) {
     llvm::IRBuilder<> ir(
         llvm::BasicBlock::Create(source_func->getContext(), "", source_func));
-
-    std::vector<llvm::Value *> args;
-    for (llvm::Argument &arg : source_func->args()) {
-      args.push_back(&arg);
-    }
-
-    llvm::CallInst *call_target_instr = ir.CreateCall(dest_func, args);
-    call_target_instr->setTailCall(true);
-    ir.CreateRet(call_target_instr);
-    return call_target_instr;
-  } else {
-    return AddTerminatingTailCall(&(source_func->back()), dest_func);
   }
+  return AddTerminatingTailCall(&(source_func->back()), dest_func);
 }
 
 llvm::CallInst *AddTerminatingTailCall(llvm::BasicBlock *source_block,

--- a/remill/BC/Util.cpp
+++ b/remill/BC/Util.cpp
@@ -439,17 +439,6 @@ static const char *gSemanticsSearchPaths[6] = {
 
 }  // namespace
 
-// Find the path to the semantics bitcode file associated with `FLAGS_arch`.
-std::string FindTargetSemanticsBitcodeFile(void) {
-  return FindSemanticsBitcodeFile(FLAGS_arch);
-}
-
-// Find the path to the semantics bitcode file associated with `REMILL_ARCH`,
-// the architecture on which remill is compiled.
-std::string FindHostSemanticsBitcodeFile(void) {
-  return FindSemanticsBitcodeFile(REMILL_ARCH);
-}
-
 // Find the path to the semantics bitcode file.
 std::string FindSemanticsBitcodeFile(const std::string &arch) {
   for (auto sem_dir : gSemanticsSearchPaths) {

--- a/remill/BC/Util.h
+++ b/remill/BC/Util.h
@@ -112,21 +112,21 @@ llvm::GlobalVariable *FindGlobaVariable(llvm::Module *M, std::string name);
 bool VerifyModule(llvm::Module *module);
 
 // Parses and loads a bitcode file into memory.
-llvm::Module *LoadModuleFromFile(llvm::LLVMContext *context,
-                                 std::string file_name,
-                                 bool allow_failure=false);
+std::unique_ptr<llvm::Module> LoadModuleFromFile(llvm::LLVMContext *context,
+                                                 std::string file_name,
+                                                 bool allow_failure=false);
 
 // Loads the semantics for the "host" machine, i.e. the machine that this
 // remill is compiled on.
-llvm::Module *LoadHostSemantics(llvm::LLVMContext &context);
+std::unique_ptr<llvm::Module> LoadHostSemantics(llvm::LLVMContext &context);
 
 // Loads the semantics for the "target" machine, i.e. the machine of the
 // code that we want to lift.
-llvm::Module *LoadTargetSemantics(llvm::LLVMContext &context);
+std::unique_ptr<llvm::Module> LoadTargetSemantics(llvm::LLVMContext &context);
 
 // Loads the semantics for the `arch`-specific machine, i.e. the machine of the
 // code that we want to lift.
-llvm::Module *LoadArchSemantics(const Arch *arch);
+std::unique_ptr<llvm::Module> LoadArchSemantics(const Arch *arch);
 
 // Store an LLVM module into a file.
 bool StoreModuleToFile(llvm::Module *module, std::string file_name,

--- a/remill/BC/Util.h
+++ b/remill/BC/Util.h
@@ -136,13 +136,6 @@ bool StoreModuleToFile(llvm::Module *module, std::string file_name,
 bool StoreModuleIRToFile(llvm::Module *module, std::string file_name,
                          bool allow_failure=false);
 
-// Find the path to the semantics bitcode file associated with `FLAGS_arch`.
-std::string FindTargetSemanticsBitcodeFile(void);
-
-// Find the path to the semantics bitcode file associated with `REMILL_ARCH`,
-// the architecture on which remill is compiled.
-std::string FindHostSemanticsBitcodeFile(void);
-
 // Find a semantics fitcode file for the architecture `arch`.
 std::string FindSemanticsBitcodeFile(const std::string &arch);
 

--- a/tests/AArch64/Lift.cpp
+++ b/tests/AArch64/Lift.cpp
@@ -181,7 +181,7 @@ extern "C" int main(int argc, char *argv[]) {
 
   auto bc_file = remill::FindSemanticsBitcodeFile(FLAGS_arch);
   auto module = remill::LoadModuleFromFile(context, bc_file);
-  remill::GetHostArch(*context)->PrepareModule(module);
+  remill::GetHostArch(*context)->PrepareModule(module.get());
 
   for (auto i = 0U; ; ++i) {
     const auto &test = test::__aarch64_test_table_begin[i];
@@ -190,7 +190,7 @@ extern "C" int main(int argc, char *argv[]) {
   }
 
   DLOG(INFO) << "Serializing bitcode to " << FLAGS_bc_out;
-  remill::StoreModuleToFile(module, FLAGS_bc_out);
+  remill::StoreModuleToFile(module.get(), FLAGS_bc_out);
 
   DLOG(INFO) << "Done.";
   return 0;

--- a/tests/X86/Lift.cpp
+++ b/tests/X86/Lift.cpp
@@ -125,7 +125,7 @@ extern "C" int main(int argc, char *argv[]) {
   auto arch = remill::Arch::Get(context, os, arch_name);
   auto module = remill::LoadArchSemantics(arch);
 
-  remill::IntrinsicTable intrinsics(module);
+  remill::IntrinsicTable intrinsics(module.get());
   remill::InstructionLifter inst_lifter(arch, intrinsics);
   remill::TraceLifter trace_lifter(inst_lifter, manager);
 
@@ -145,8 +145,8 @@ extern "C" int main(int argc, char *argv[]) {
   }
 
   DLOG(INFO) << "Serializing bitcode to " << FLAGS_bc_out;
-  remill::GetHostArch(context)->PrepareModule(module);
-  remill::StoreModuleToFile(module, FLAGS_bc_out);
+  remill::GetHostArch(context)->PrepareModule(module.get());
+  remill::StoreModuleToFile(module.get(), FLAGS_bc_out);
 
   DLOG(INFO) << "Done.";
   return 0;


### PR DESCRIPTION
Tries to improve memory management of `llvm::Module` to be more modern-C++ oriented.
Also removes some API calls that are internally dependent on global `FLAGS` with only benefit being that users are allowed to skip a few strokes.
Lastly removes some indirect code duplication.