### PR TITLE
Annotate semantics

### DIFF
--- a/remill/Arch/Name.h
+++ b/remill/Arch/Name.h
@@ -55,9 +55,6 @@ enum ArchName : uint32_t {
   kArchAMD64_AVX,
   kArchAMD64_AVX512,
 
-  kArchMips32,
-  kArchMips64,
-
   kArchAArch64LittleEndian
 };
 

--- a/remill/BC/Annotate.cpp
+++ b/remill/BC/Annotate.cpp
@@ -37,17 +37,20 @@ const std::string CFGExternal::metadata_value = ExternalFunction::metadata_value
                                                 "cfgexternal";
 
 const std::string ExtWrapper::metadata_value = ExternalFunction::metadata_value + "." +
-                                                "extwrapper";
+                                               "extwrapper";
 
 
 const std::string Helper::metadata_value = BaseFunction::metadata_value + "." + "helper";
 
 
 const std::string RemillHelper::metadata_value = Helper::metadata_value + "." +
-                                                  "remill";
+                                                 "remill";
 
 const std::string McSemaHelper::metadata_value = Helper::metadata_value + "." +
                                                  "mcsema";
+
+const std::string Semantics::metadata_value = Helper::metadata_value + "." +
+                                              "semantics";
 
 #if LLVM_VERSION_NUMBER >= LLVM_VERSION(4, 0)
 

--- a/remill/BC/Annotate.h
+++ b/remill/BC/Annotate.h
@@ -57,6 +57,7 @@ DECLARE_FUNC_ORIGIN_TYPE(ExtWrapper, ExternalFunction);
 DECLARE_FUNC_ORIGIN_TYPE(Helper, BaseFunction);
 DECLARE_FUNC_ORIGIN_TYPE(RemillHelper, Helper);
 DECLARE_FUNC_ORIGIN_TYPE(McSemaHelper, Helper);
+DECLARE_FUNC_ORIGIN_TYPE(Semantics, Helper);
 
 #undef DECLARE_FUNC_ORIGIN_TYPE
 

--- a/remill/BC/Util.cpp
+++ b/remill/BC/Util.cpp
@@ -46,6 +46,7 @@
 #include "remill/Arch/Arch.h"
 #include "remill/Arch/Name.h"
 #include "remill/BC/ABI.h"
+#include "remill/BC/Annotate.h"
 #include "remill/BC/Compat/BitcodeReaderWriter.h"
 #include "remill/BC/Compat/DebugInfo.h"
 #include "remill/BC/Compat/GlobalValue.h"
@@ -259,6 +260,9 @@ std::unique_ptr<llvm::Module> LoadArchSemantics(const Arch *arch) {
       << "Loading " << arch_name << " semantics from file " << path;
   auto module = LoadModuleFromFile(arch->context, path);
   arch->PrepareModule(module);
+  for (auto &func : *module) {
+    Annotate<remill::Semantics>(&func);
+  }
   return module;
 }
 


### PR DESCRIPTION
Adds another type of annotation for loaded semantics functions.
(For example it may be desirable to inline only these functions and no other wrappers.)

As a bonus unused enum value for Mips is removed (was forgotten in one of the previous PRs).