### PR TITLE
Update .dockerignore for faster docker builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,5 @@
+build
+remill-build
 Dockerfile*
 .travis.yml
 .git*


### PR DESCRIPTION
* Update `.dockerignore` file with sane defaults to make faster docker builds (don't include a build or remill-build directory if there is one)