### PR TITLE
Remove gnu_inline from ALWAYS_INLINE

### DIFF
--- a/remill/Arch/Runtime/Definitions.h
+++ b/remill/Arch/Runtime/Definitions.h
@@ -44,7 +44,7 @@
 
 // Attributes that will force inlining of specific code.
 #define ALWAYS_INLINE \
-  [[gnu::always_inline, gnu::gnu_inline]] \
+  [[gnu::always_inline]] \
   inline
 
 #define NEVER_INLINE [[gnu::noinline]]


### PR DESCRIPTION
Clang10 behaves differently on gnu_inline, and gnu behavior is probably not needed here.