### PR TITLE
Fix CVTSI2SS for recent update of Intel XED

### DIFF
--- a/lib/Arch/X86/Semantics/CONVERT.cpp
+++ b/lib/Arch/X86/Semantics/CONVERT.cpp
@@ -341,10 +341,10 @@ DEF_SEM(CVTSI2SS, V128W dst, V128 src1, S2 src2) {
 }
 
 template <typename S2>
-DEF_SEM(CVTSI2SD, V128W dst_src1, S2 src2) {
-  auto src1_vec = FReadV64(dst_src1);
+DEF_SEM(CVTSI2SD, V128W dst, V128 src1, S2 src2) {
+  auto src1_vec = FReadV64(src1);
   auto conv_val = Float64(Signed(Read(src2)));
-  FWriteV64(dst_src1, FInsertV64(src1_vec, 0, conv_val));
+  FWriteV64(dst, FInsertV64(src1_vec, 0, conv_val));
   return memory;
 }
 

--- a/lib/Arch/X86/Semantics/CONVERT.cpp
+++ b/lib/Arch/X86/Semantics/CONVERT.cpp
@@ -333,10 +333,10 @@ IF_AVX(DEF_ISEL(VCVTSD2SS_XMMdq_XMMdq_XMMq) = VCVTSD2SS<V128>;)
 
 namespace {
 template <typename S2>
-DEF_SEM(CVTSI2SS, V128W dst_src1, S2 src2) {
-  auto src1_vec = FReadV32(dst_src1);
+DEF_SEM(CVTSI2SS, V128W dst, V128 src1, S2 src2) {
+  auto src1_vec = FReadV32(src1);
   auto conv_val = Float32(Signed(Read(src2)));
-  FWriteV32(dst_src1, FInsertV32(src1_vec, 0, conv_val));
+  FWriteV32(dst, FInsertV32(src1_vec, 0, conv_val));
   return memory;
 }
 


### PR DESCRIPTION
Note that it may be needed to build XED from the latest revision, rather than using the cached build from docker images.

## Issue

After building and installing `cxx-common` 0.0.14 from scratch, Remill's build succeeded, but the tests failed with the following error messages, which can be reproduced on Arch Linux and Ubuntu 18.04, with Remill 4.0.8 and 4.0.9.
```
$ make test_dependencies
<...ignored...>
[ 53%] Generating tests_amd64_avx.bc
cd /home/kyc/aur/remill/src/remill-4.0.9/build/tests/X86 && ./lift-amd64_avx-tests --arch amd64_avx --bc_out tests_amd64_avx.bc
F20201120 08:38:18.335090 23722 InstructionLifter.cpp:576] Check failed: val_type->isIntegerTy() Expected XMM0 to be an integral type for instruction at 56b4e0
inst.Serialize(): (AMD64 56b4e0 (BYTES f3 0f 2a c7) CVTSI2SS_XMMss_GPR32d (WRITE_OP (REG_256 YMM0)) (READ_OP (REG_128 XMM0)) (READ_OP (REG_32 EDI)))
*** Check failure stack trace: ***
    @           0xdea674  google::LogMessage::Flush()
    @           0xdedcbc  google::LogMessageFatal::~LogMessageFatal()
    @           0x5920e0  remill::InstructionLifter::LiftRegisterOperand()
    @           0x58f8d5  remill::InstructionLifter::LiftIntoBlock()
    @           0x595dee  remill::TraceLifter::Impl::Lift()
    @           0x5954ec  remill::TraceLifter::Lift()
    @           0x56810a  main
    @     0x7fb9733e8152  __libc_start_main
    @           0x567c7e  _start
make[3]: *** [tests/X86/CMakeFiles/run-amd64_avx-tests.dir/build.make:88: tests/X86/tests_amd64_avx.bc] Aborted (core dumped)
make[3]: Leaving directory '/home/kyc/aur/remill/src/remill-4.0.9/build'
make[2]: *** [CMakeFiles/Makefile2:2125: tests/X86/CMakeFiles/run-amd64_avx-tests.dir/all] Error 2
make[2]: Leaving directory '/home/kyc/aur/remill/src/remill-4.0.9/build'
make[1]: *** [CMakeFiles/Makefile2:466: CMakeFiles/test_dependencies.dir/rule] Error 2
make[1]: Leaving directory '/home/kyc/aur/remill/src/remill-4.0.9/build'
make: *** [Makefile:197: test_dependencies] Error 2
```
