### PR TITLE
vmill requested functionality

### DIFF
--- a/include/remill/BC/InstructionLifter.h
+++ b/include/remill/BC/InstructionLifter.h
@@ -43,6 +43,9 @@ class TraceLifter;
 enum LiftStatus {
   kLiftedInvalidInstruction,
   kLiftedUnsupportedInstruction,
+  kLiftedLifterError,
+  kLiftedUnknownISEL,
+  kLiftedMismatchedISEL,
   kLiftedInstruction
 };
 

--- a/lib/BC/InstructionLifter.cpp
+++ b/lib/BC/InstructionLifter.cpp
@@ -165,10 +165,9 @@ LiftStatus InstructionLifter::LiftIntoBlock(Instruction &arch_inst,
   auto arg_num = 2U;
 
   for (auto &op : arch_inst.operands) {
-    CHECK(arg_num < isel_func_type->getNumParams())
-        << "Function " << arch_inst.function << ", implemented by "
-        << isel_func->getName().str() << ", should have at least " << arg_num
-        << " arguments for instruction " << arch_inst.Serialize();
+    if (!(arg_num < isel_func_type->getNumParams())) {
+      return kLiftedMismatchedISEL;
+    }
 
     auto arg = NthArgument(isel_func, arg_num);
     auto arg_type = arg->getType();


### PR DESCRIPTION
`InstructionLifter` currently asserts, when it cannot match arguments to the chosen `ISEL`. While this is what one can consider an "internal error" I believe it is better to return error code to the user so it can be dealt with.