### PR TITLE
Fixes a too-strict check in building a pointer to an offset. Check di…

### DIFF
--- a/lib/BC/Util.cpp
+++ b/lib/BC/Util.cpp
@@ -2000,7 +2000,7 @@ llvm::Value *BuildPointerToOffset(llvm::IRBuilder<> &ir, llvm::Value *ptr,
 
   if (const auto diff = dest_elem_offset - reached_disp; diff) {
     DCHECK_LT(diff, dest_elem_offset);
-    DCHECK_LT(diff, dl.getTypeAllocSize(indexed_type));
+    DCHECK_LE(diff, dl.getTypeAllocSize(indexed_type));
     const auto i8_type = llvm::Type::getInt8Ty(context);
     const auto i8_ptr_type =
         llvm::PointerType::getInt8PtrTy(context, ptr_addr_space);


### PR DESCRIPTION
…d not consider the case where we're indexing into the padding between member elements of a struct