### PR TITLE
Limit MacOS CI Runners

### DIFF
--- a/.github/workflows/vcpkg_ci.yml
+++ b/.github/workflows/vcpkg_ci.yml
@@ -59,12 +59,9 @@ jobs:
       fail-fast: false
       matrix:
         os: [
-          'macos-10.15',
           'macos-11.0'
           ]
         llvm: [
-          '9',
-          '10',
           '11'
           ]
 


### PR DESCRIPTION
Limit MacOS CI Runners due to organizational limits