### PR TITLE
AArch32/Decode.cpp - Add missing header

### DIFF
--- a/lib/Arch/AArch32/Decode.cpp
+++ b/lib/Arch/AArch32/Decode.cpp
@@ -15,6 +15,7 @@
  */
 
 #include <glog/logging.h>
+#include <optional>
 
 #include "Arch.h"
 #include "remill/BC/ABI.h"


### PR DESCRIPTION
Fix Windows build