### PR TITLE
Instruction category for indirect jump & function return

### DIFF
--- a/lib/Arch/AArch32/Semantics/BRANCH.cpp
+++ b/lib/Arch/AArch32/Semantics/BRANCH.cpp
@@ -33,8 +33,8 @@ DEF_SEM(BCOND, R8 cond, R8W branch_taken, I32 taken_pc, I32 not_taken_pc,
   return memory;
 }
 
-DEF_SEM(BL, R8, R8W, PC target_addr, PC ret_addr,
-        R32W next_pc_dst, R32W return_pc_dst) {
+DEF_SEM(BL, R8, R8W, PC target_addr, PC ret_addr, R32W next_pc_dst,
+        R32W return_pc_dst) {
   const auto return_pc = Read(ret_addr);
   const auto new_pc = Read(target_addr);
   Write(REG_LR, return_pc);


### PR DESCRIPTION
The PR reverts some of the changes that identify the updates of `PC` with the return address. All instructions updating PC directly with `LR` (return address) are categorized as return type. Others get categorized as indirect Jump. At a later stage, the lifter will identify if the return address ends up getting into PC and handle them accordingly. 