### PR TITLE
Add Reverse Bit/Byte support in AArch32 Semantics

### DIFF
--- a/lib/Arch/AArch32/Decode.cpp
+++ b/lib/Arch/AArch32/Decode.cpp
@@ -3100,11 +3100,8 @@ static TryDecode *TryMedia(uint32_t bits) {
     case 0b11100000:
     case 0b11100100:
     case 0b11101000:
-    case 0b11101100:
-
-      // Bitfield Insert
+    case 0b11101100: return TryBitInsert;
     case 0b11111111:
-      return TryBitInsert;
 
       // Permanently UNDEFINED
       return nullptr;

--- a/lib/Arch/AArch32/Decode.cpp
+++ b/lib/Arch/AArch32/Decode.cpp
@@ -2545,10 +2545,10 @@ static bool TryDecodeMoveHalfword(Instruction &inst, uint32_t bits) {
   AddImmOp(inst, enc.imm4 << 12 | enc.imm12);
   if (!enc.H) {
     AddImmOp(inst, 0);
+
     // Add kIgnoreNextPCVariableName to allow MOVW to share semantics with ORR
     AddAddrRegOp(inst, kIgnoreNextPCVariableName.data(), kAddressSize,
                  Operand::kActionWrite, 0);
-
   }
   inst.category = Instruction::kCategoryNormal;
   return true;
@@ -3103,7 +3103,8 @@ static TryDecode *TryMedia(uint32_t bits) {
     case 0b11101100:
 
       // Bitfield Insert
-    case 0b11111111: return TryBitInsert;
+    case 0b11111111:
+      return TryBitInsert;
 
       // Permanently UNDEFINED
       return nullptr;
@@ -3595,7 +3596,8 @@ bool AArch32Arch::DecodeInstruction(uint64_t address,
   }
 
   auto ret = decoder(inst, bits);
-//  LOG(ERROR) << inst.Serialize();
+
+  //  LOG(ERROR) << inst.Serialize();
   return ret;
 }
 

--- a/lib/Arch/AArch32/Decode.cpp
+++ b/lib/Arch/AArch32/Decode.cpp
@@ -2945,12 +2945,6 @@ static bool TryReverseBitByte(Instruction &inst, uint32_t bits) {
 
   inst.function = kRevBitByte[enc.o1 << 1 | enc.o2];
 
-  // TODO(sks): Support REV16, RBIT, & REVSH
-  if (enc.o1 || enc.o2) {
-    inst.category = Instruction::kCategoryError;
-    return false;
-  }
-
   // if d == 15 || m == 15 then UNPREDICTABLE;
   if (enc.Rd == kPCRegNum || enc.Rm == kPCRegNum) {
     inst.category = Instruction::kCategoryError;
@@ -3548,7 +3542,7 @@ bool AArch32Arch::DecodeInstruction(uint64_t address,
   }
 
   auto ret = decoder(inst, bits);
-//  LOG(ERROR) << inst.Serialize();
+  LOG(ERROR) << inst.Serialize();
   return ret;
 }
 

--- a/lib/Arch/AArch32/Decode.cpp
+++ b/lib/Arch/AArch32/Decode.cpp
@@ -3542,7 +3542,7 @@ bool AArch32Arch::DecodeInstruction(uint64_t address,
   }
 
   auto ret = decoder(inst, bits);
-  LOG(ERROR) << inst.Serialize();
+//  LOG(ERROR) << inst.Serialize();
   return ret;
 }
 

--- a/lib/Arch/AArch32/Semantics/BITBYTE.cpp
+++ b/lib/Arch/AArch32/Semantics/BITBYTE.cpp
@@ -59,6 +59,7 @@ DEF_COND_SEM(BFC, R32W dst, R32 src1, I32 msb, I32 lsb) {
 DEF_ISEL(BFI) = BFI;
 DEF_ISEL(BFC) = BFC;
 
+
 // Bitfield Extract
 namespace {
 DEF_COND_SEM(SBFX, R32W dst, R32 src1, I32 src2, I32 src3) {
@@ -92,15 +93,18 @@ DEF_COND_SEM(UBFX, R32W dst, R32 src1, I32 src2, I32 src3) {
 DEF_ISEL(SBFX) = SBFX;
 DEF_ISEL(UBFX) = UBFX;
 
-namespace {
 
+// Reverse Bit/Byte
+namespace {
 DEF_COND_SEM(REV, R32W dst, R32 src1) {
   auto src = Read(src1);
 
-  auto res_31_24 = UShl(src, uint32_t(24u)); // result<31:24> = R[m]<7:0>;
-  auto res_23_16 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 16u)); // result<23:16> = R[m]<15:8>;
-  auto res_15_8 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u << 8u)); // result<15:8>  = R[m]<23:16>;
-  auto res_7_0 = UShr(src, uint32_t(24)); // result<7:0>   = R[m]<31:24>;
+  auto res_31_24 = UShl(src, uint32_t(24u));  // result<31:24> = R[m]<7:0>;
+  auto res_23_16 = UAnd(UShl(src, uint32_t(8u)),
+                        uint32_t(255u << 16u));  // result<23:16> = R[m]<15:8>;
+  auto res_15_8 = UAnd(UShr(src, uint32_t(8u)),
+                       uint32_t(255u << 8u));  // result<15:8>  = R[m]<23:16>;
+  auto res_7_0 = UShr(src, uint32_t(24));  // result<7:0>   = R[m]<31:24>;
 
   auto res = UOr(res_31_24, UOr(res_23_16, UOr(res_15_8, res_7_0)));
 
@@ -111,10 +115,14 @@ DEF_COND_SEM(REV, R32W dst, R32 src1) {
 DEF_COND_SEM(REV16, R32W dst, R32 src1) {
   auto src = Read(src1);
 
-  auto res_31_24 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 24u)); // result<31:24> = R[m]<23:16>;
-  auto res_23_16 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u << 16u)); // result<23:16> = R[m]<31:24>;
-  auto res_15_8 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 8u)); // result<15:8>  = R[m]<7:0>;
-  auto res_7_0 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u)); // result<7:0>   = R[m]<15:8>;
+  auto res_31_24 = UAnd(UShl(src, uint32_t(8u)),
+                        uint32_t(255u << 24u));  // result<31:24> = R[m]<23:16>;
+  auto res_23_16 = UAnd(UShr(src, uint32_t(8u)),
+                        uint32_t(255u << 16u));  // result<23:16> = R[m]<31:24>;
+  auto res_15_8 = UAnd(UShl(src, uint32_t(8u)),
+                       uint32_t(255u << 8u));  // result<15:8>  = R[m]<7:0>;
+  auto res_7_0 = UAnd(UShr(src, uint32_t(8u)),
+                      uint32_t(255u));  // result<7:0>   = R[m]<15:8>;
 
   auto res = UOr(res_31_24, UOr(res_23_16, UOr(res_15_8, res_7_0)));
 
@@ -143,16 +151,15 @@ DEF_COND_SEM(RBIT, R32W dst, R32 src) {
 DEF_COND_SEM(REVSH, R32W dst, R32 src1) {
   auto src = Trunc(Read(src1));
 
-  auto result_31_8 = Unsigned(SExt(UShl(src, uint16_t(8u)))); //SignExtend(R[m]<7:0>, 24);
-  auto result_7_0 = ZExt(UShr(Unsigned(src), uint16_t(8u))); //R[m]<15:8>;
+  auto result_31_8 =
+      Unsigned(SExt(UShl(src, uint16_t(8u))));  //SignExtend(R[m]<7:0>, 24);
+  auto result_7_0 = ZExt(UShr(Unsigned(src), uint16_t(8u)));  //R[m]<15:8>;
 
   auto res = UOr(result_31_8, result_7_0);
 
   Write(dst, res);
   return memory;
 }
-
-
 }  // namespace
 
 DEF_ISEL(REV) = REV;

--- a/lib/Arch/AArch32/Semantics/BITBYTE.cpp
+++ b/lib/Arch/AArch32/Semantics/BITBYTE.cpp
@@ -75,6 +75,26 @@ DEF_COND_SEM(REV, R32W dst, R32 src1) {
 
 }
 
+DEF_COND_SEM(REV16, R32W dst, R32 src1) {
+
+  auto src = Read(src1);
+
+  auto res_31_24 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 24u)); // result<31:24> = R[m]<23:16>;
+  auto res_23_16 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u << 16u)); // result<23:16> = R[m]<31:24>;
+  auto res_15_8 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 8u)); // result<15:8>  = R[m]<7:0>;
+  auto res_7_0 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u)); // result<7:0>   = R[m]<15:8>;
+
+  auto res = UOr(res_31_24, UOr(res_23_16, UOr(res_15_8, res_7_0)));
+
+  Write(dst, res);
+  return memory;
+
+}
+
+
 }  // namespace
 
 DEF_ISEL(REV) = REV;
+DEF_ISEL(REV16) = REV16;
+//DEF_ISEL(RBIT) = RBIT;
+//DEF_ISEL(REVSH) = REVSH;

--- a/lib/Arch/AArch32/Semantics/BITBYTE.cpp
+++ b/lib/Arch/AArch32/Semantics/BITBYTE.cpp
@@ -59,13 +59,13 @@ DEF_ISEL(UBFX) = UBFX;
 
 namespace {
 
-DEF_COND_SEM(REV, R32W dst, R32 src) {
+DEF_COND_SEM(REV, R32W dst, R32 src1) {
 
-  auto src = Read(src);
+  auto src = Read(src1);
 
-  auto res_31_24 = UShl(src); // result<31:24> = R[m]<7:0>;
-  auto res_23_16 = UAnd(UShl(src, uint32_t(8)), uint32_t(255u << 16)); // result<23:16> = R[m]<15:8>;
-  auto res_15_8 = UAnd(UShr(src, uint32_t(8)), uint32_t(255u << 8)); // result<15:8>  = R[m]<23:16>;
+  auto res_31_24 = UShl(src, uint32_t(24u)); // result<31:24> = R[m]<7:0>;
+  auto res_23_16 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 16u)); // result<23:16> = R[m]<15:8>;
+  auto res_15_8 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u << 8u)); // result<15:8>  = R[m]<23:16>;
   auto res_7_0 = UShr(src, uint32_t(24)); // result<7:0>   = R[m]<31:24>;
 
   auto res = UOr(res_31_24, UOr(res_23_16, UOr(res_15_8, res_7_0)));

--- a/lib/Arch/AArch32/Semantics/BITBYTE.cpp
+++ b/lib/Arch/AArch32/Semantics/BITBYTE.cpp
@@ -60,7 +60,6 @@ DEF_ISEL(UBFX) = UBFX;
 namespace {
 
 DEF_COND_SEM(REV, R32W dst, R32 src1) {
-
   auto src = Read(src1);
 
   auto res_31_24 = UShl(src, uint32_t(24u)); // result<31:24> = R[m]<7:0>;
@@ -72,11 +71,9 @@ DEF_COND_SEM(REV, R32W dst, R32 src1) {
 
   Write(dst, res);
   return memory;
-
 }
 
 DEF_COND_SEM(REV16, R32W dst, R32 src1) {
-
   auto src = Read(src1);
 
   auto res_31_24 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 24u)); // result<31:24> = R[m]<23:16>;
@@ -88,7 +85,32 @@ DEF_COND_SEM(REV16, R32W dst, R32 src1) {
 
   Write(dst, res);
   return memory;
+}
 
+//DEF_COND_SEM(RBIT, R32W dst, R32 src1) {
+//  auto src = Read(src1);
+//
+//  auto res_31_24 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 24u)); // result<31:24> = R[m]<23:16>;
+//  auto res_23_16 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u << 16u)); // result<23:16> = R[m]<31:24>;
+//  auto res_15_8 = UAnd(UShl(src, uint32_t(8u)), uint32_t(255u << 8u)); // result<15:8>  = R[m]<7:0>;
+//  auto res_7_0 = UAnd(UShr(src, uint32_t(8u)), uint32_t(255u)); // result<7:0>   = R[m]<15:8>;
+//
+//  auto res = UOr(res_31_24, UOr(res_23_16, UOr(res_15_8, res_7_0)));
+//
+//  Write(dst, res);
+//  return memory;
+//}
+
+DEF_COND_SEM(REVSH, R32W dst, R32 src1) {
+  auto src = Trunc(Read(src1));
+
+  auto result_31_8 = Unsigned(SExt(UShl(src, uint16_t(8u)))); //SignExtend(R[m]<7:0>, 24);
+  auto result_7_0 = ZExt(UShr(Unsigned(src), uint16_t(8u))); //R[m]<15:8>;
+
+  auto res = UOr(result_31_8, result_7_0);
+
+  Write(dst, res);
+  return memory;
 }
 
 
@@ -97,4 +119,4 @@ DEF_COND_SEM(REV16, R32W dst, R32 src1) {
 DEF_ISEL(REV) = REV;
 DEF_ISEL(REV16) = REV16;
 //DEF_ISEL(RBIT) = RBIT;
-//DEF_ISEL(REVSH) = REVSH;
+DEF_ISEL(REVSH) = REVSH;

--- a/lib/Arch/AArch32/Semantics/BITBYTE.cpp
+++ b/lib/Arch/AArch32/Semantics/BITBYTE.cpp
@@ -56,3 +56,25 @@ DEF_COND_SEM(UBFX, R32W dst, R32 src1, I32 src2, I32 src3) {
 
 DEF_ISEL(SBFX) = SBFX;
 DEF_ISEL(UBFX) = UBFX;
+
+namespace {
+
+DEF_COND_SEM(REV, R32W dst, R32 src) {
+
+  auto src = Read(src);
+
+  auto res_31_24 = UShl(src); // result<31:24> = R[m]<7:0>;
+  auto res_23_16 = UAnd(UShl(src, uint32_t(8)), uint32_t(255u << 16)); // result<23:16> = R[m]<15:8>;
+  auto res_15_8 = UAnd(UShr(src, uint32_t(8)), uint32_t(255u << 8)); // result<15:8>  = R[m]<23:16>;
+  auto res_7_0 = UShr(src, uint32_t(24)); // result<7:0>   = R[m]<31:24>;
+
+  auto res = UOr(res_31_24, UOr(res_23_16, UOr(res_15_8, res_7_0)));
+
+  Write(dst, res);
+  return memory;
+
+}
+
+}  // namespace
+
+DEF_ISEL(REV) = REV;

--- a/lib/Arch/AArch32/Semantics/BITBYTE.cpp
+++ b/lib/Arch/AArch32/Semantics/BITBYTE.cpp
@@ -24,6 +24,41 @@ DEF_COND_SEM(CLZ, R32W dst, R32 src) {
 
 DEF_ISEL(CLZ) = CLZ;
 
+// Bitfield Insert
+namespace {
+DEF_COND_SEM(BFI, R32W dst, R32 src1, R32 src2, I32 msb, I32 lsb) {
+  auto rd = Read(src1);
+  auto rn = Read(src2);
+  auto msbit = Read(msb);
+  auto lsbit = Read(lsb);
+
+  auto width = msbit - lsbit + 1;
+  auto mask = uint32_t((1 << width) - 1);
+
+  auto res = UOr(rd, UShl(UAnd(rn, mask), lsbit));
+
+  Write(dst, res);
+  return memory;
+}
+
+DEF_COND_SEM(BFC, R32W dst, R32 src1, I32 msb, I32 lsb) {
+  auto rd = Read(src1);
+  auto msbit = Read(msb);
+  auto lsbit = Read(lsb);
+
+  auto width = msbit - lsbit + 1;
+  auto mask = uint32_t(((1 << width) - 1) << (lsbit + 1));
+
+  auto res = UAnd(rd, UNot(mask));
+
+  Write(dst, res);
+  return memory;
+}
+}  // namespace
+
+DEF_ISEL(BFI) = BFI;
+DEF_ISEL(BFC) = BFC;
+
 // Bitfield Extract
 namespace {
 DEF_COND_SEM(SBFX, R32W dst, R32 src1, I32 src2, I32 src3) {


### PR DESCRIPTION
Test Instructions for `Reverse Bit/Byte`:

- [x]  REV R1, R2    -   21fbfe6
- [x]  REV16 R1, R3   -   b31fbfe6
- [x]  RBIT R1, R4.   -    341fffe6
- [x]  REVSH R1, R5   -   b51fffe6

Also added `Bitfield Insert`:

- [x] BFC R1, `#3`, `#4` - 9f11c6e7
- [x] BFI R1, R2, `#5`, `#4` - 9212c8e7

to make sure we cover all basic bit insert/rotation/extraction operations