### PR TITLE
Fix build on M1 Mac

### DIFF
--- a/lib/Arch/AArch32/Runtime/CMakeLists.txt
+++ b/lib/Arch/AArch32/Runtime/CMakeLists.txt
@@ -37,7 +37,7 @@ function(add_runtime_helper target_name little_endian)
 
   # necessary to build code as 32-bit
   # on aarch64
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)" AND "${PLATFORM_NAME}" STREQUAL "linux")
     set(arch_flags "--target=arm-linux-gnueabihf")
   else()
     set(arch_flags "-m32")

--- a/lib/Arch/SPARC32/Runtime/CMakeLists.txt
+++ b/lib/Arch/SPARC32/Runtime/CMakeLists.txt
@@ -40,7 +40,7 @@ function(add_runtime_helper target_name little_endian)
 
   # necessary to build code as 32-bit
   # on aarch64
-  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)")
+  if(CMAKE_SYSTEM_PROCESSOR MATCHES "^(aarch64.*|AARCH64.*|arm64.*|ARM64.*)" AND "${PLATFORM_NAME}" STREQUAL "linux")
     set(arch_flags "--target=arm-linux-gnueabihf")
   else()
     set(arch_flags "-m32")


### PR DESCRIPTION
We're using the target `arm-linux-gnueabihf` which is unrecognised on Apple Clang. I'm thinking we should add a check that we're on Linux and avoid using that target otherwise.