### PR TITLE
Remove an unnecessary CHECK_EQ on the remill::Arch context, and the m…

### DIFF
--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -642,7 +642,6 @@ void Arch::PrepareModuleDataLayout(llvm::Module *mod) const {
 }
 
 void Arch::PrepareModule(llvm::Module *mod) const {
-  CHECK_EQ(&(mod->getContext()), context);
   PrepareModuleDataLayout(mod);
 }
 


### PR DESCRIPTION
…odule context being prepared.