### PR TITLE
bc: Remove compat methods from CallSite that handled InvokeInst.

### DIFF
--- a/include/remill/BC/Compat/CallSite.h
+++ b/include/remill/BC/Compat/CallSite.h
@@ -42,7 +42,6 @@ struct CallSite : private ::llvm::CallSite {
      * as well.
      */
   using parent::isCall;
-  using parent::isInvoke;
   using parent::parent;
   using parent::operator bool;
   using parent::getCalledFunction;
@@ -68,10 +67,6 @@ struct CallSite {
 
   CallSite(::llvm::User *user)
       : CallSite(::llvm::dyn_cast_or_null<::llvm::Instruction>(user)) {}
-
-  bool isInvoke() const {
-    return cb && ::llvm::isa<::llvm::InvokeInst>(*cb);
-  }
 
   bool isCall() const {
     return cb && ::llvm::isa<::llvm::CallInst>(*cb);


### PR DESCRIPTION
This compat file is probably not used, but including it in a user program with llvm-14 will result in hard compilation error.