### PR TITLE
Pass opaque pointer flag to Clang so it can handle Remill's IR

### DIFF
--- a/lib/BC/Optimizer.cpp
+++ b/lib/BC/Optimizer.cpp
@@ -56,7 +56,10 @@ void OptimizeModule(const remill::Arch *arch, llvm::Module *module,
   TLI->disableAllFunctions();  // `-fno-builtin`.
 
   llvm::PassManagerBuilder builder;
-  builder.OptLevel = 3;
+  // TODO(alex): Some of the optimization passes that the builder adds still rely on typed pointers
+  // so we cannot use them. We should switch to using the new pass manager and choose which passes
+  // we want.
+  builder.OptLevel = 0;
   builder.SizeLevel = 0;
   builder.Inliner = llvm::createFunctionInliningPass(250);
   builder.LibraryInfo = TLI;  // Deleted by `llvm::~PassManagerBuilder`.
@@ -94,7 +97,10 @@ void OptimizeBareModule(llvm::Module *module, OptimizationGuide guide) {
   TLI->disableAllFunctions();  // `-fno-builtin`.
 
   llvm::PassManagerBuilder builder;
-  builder.OptLevel = 3;
+  // TODO(alex): Some of the optimization passes that the builder adds still rely on typed pointers
+  // so we cannot use them. We should switch to using the new pass manager and choose which passes
+  // we want.
+  builder.OptLevel = 0;
   builder.SizeLevel = 0;
   builder.Inliner = llvm::createFunctionInliningPass(250);
   builder.LibraryInfo = TLI;  // Deleted by `llvm::~PassManagerBuilder`.

--- a/tests/AArch64/CMakeLists.txt
+++ b/tests/AArch64/CMakeLists.txt
@@ -71,6 +71,7 @@ add_custom_command(
           -S -O1 -g0
           -c tests_aarch64.bc
           -o tests_aarch64.S
+          -mllvm -opaque-pointers
   DEPENDS tests_aarch64.bc
 )
 

--- a/tests/AArch64/Run.cpp
+++ b/tests/AArch64/Run.cpp
@@ -143,6 +143,8 @@ MAKE_RW_FP_MEMORY(32)
 MAKE_RW_FP_MEMORY(64)
 MAKE_RW_FP_MEMORY(128)
 
+State __remill_state{};
+
 NEVER_INLINE Memory *__remill_read_memory_f80(Memory *, addr_t addr,
                                               native_float80_t &out) {
   out = AccessMemory<native_float80_t>(addr);

--- a/tests/X86/CMakeLists.txt
+++ b/tests/X86/CMakeLists.txt
@@ -24,21 +24,21 @@ function(COMPILE_X86_TESTS name address_size has_avx has_avx512)
     -DGTEST_HAS_RTTI=0
     -DGTEST_HAS_TR1_TUPLE=0
   )
-    
+
   add_executable(lift-${name}-tests
     EXCLUDE_FROM_ALL
     Lift.cpp
     Tests.S
   )
-    
+
   target_compile_options(lift-${name}-tests
     PRIVATE ${X86_TEST_FLAGS} -DIN_TEST_GENERATOR
   )
-  
+
   file(GLOB X86_TEST_FILES
     "${CMAKE_CURRENT_LIST_DIR}/*/*.S"
   )
-  
+
   set_target_properties(lift-${name}-tests PROPERTIES OBJECT_DEPENDS "${X86_TEST_FILES}")
 
   target_link_libraries(lift-${name}-tests PRIVATE remill GTest::gtest)
@@ -49,19 +49,19 @@ function(COMPILE_X86_TESTS name address_size has_avx has_avx512)
     COMMAND lift-${name}-tests --arch ${name} --bc_out tests_${name}.bc
     DEPENDS semantics
   )
-    
+
   add_custom_command(
     OUTPUT tests_${name}.S
-    COMMAND ${CMAKE_BC_COMPILER} -Wno-override-module -S -O0 -g0 -c tests_${name}.bc -o tests_${name}.S
+    COMMAND ${CMAKE_BC_COMPILER} -Wno-override-module -S -O0 -g0 -c tests_${name}.bc -o tests_${name}.S -mllvm -opaque-pointers
     DEPENDS tests_${name}.bc
   )
- 
+
   add_executable(run-${name}-tests EXCLUDE_FROM_ALL Run.cpp Tests.S tests_${name}.S)
   set_target_properties(run-${name}-tests PROPERTIES OBJECT_DEPENDS "${X86_TEST_FILES}")
 
   target_link_libraries(run-${name}-tests PUBLIC remill GTest::gtest)
   target_compile_definitions(run-${name}-tests PUBLIC ${PROJECT_DEFINITIONS})
-    
+
   target_compile_options(run-${name}-tests
     PRIVATE ${X86_TEST_FLAGS}
   )

--- a/tests/X86/Run.cpp
+++ b/tests/X86/Run.cpp
@@ -181,6 +181,8 @@ MAKE_RW_FP_MEMORY(64)
 //MAKE_RW_FP_MEMORY(80)
 MAKE_RW_FP_MEMORY(128)
 
+State __remill_state{};
+
 NEVER_INLINE Memory *__remill_read_memory_f80(Memory *, addr_t addr,
                                               native_float80_t &out) {
   out = AccessMemory<native_float80_t>(addr);


### PR DESCRIPTION
Closes #604