### PR TITLE
Implement GET_PC idiom

### DIFF
--- a/include/remill/BC/ABI.h
+++ b/include/remill/BC/ABI.h
@@ -40,7 +40,7 @@ extern const std::string_view kBranchTakenVariableName;
 
 extern const std::string_view kInvalidInstructionISelName;
 extern const std::string_view kUnsupportedInstructionISelName;
-extern const std::string_view kGetPCISelName;
+extern const std::string_view kGetPCISelPrefix;
 extern const std::string_view kIgnoreNextPCVariableName;
 
 }  // namespace remill

--- a/include/remill/BC/ABI.h
+++ b/include/remill/BC/ABI.h
@@ -40,6 +40,7 @@ extern const std::string_view kBranchTakenVariableName;
 
 extern const std::string_view kInvalidInstructionISelName;
 extern const std::string_view kUnsupportedInstructionISelName;
+extern const std::string_view kGetPCISelName;
 extern const std::string_view kIgnoreNextPCVariableName;
 
 }  // namespace remill

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -827,7 +827,6 @@ static bool TryDecodeIdioms(Instruction &inst) {
     assert(pop_inst.operands.size() == 1);
     inst.operands = std::move(pop_inst.operands);
 
-    inst.pc = call_pc;
     inst.category = Instruction::kCategoryNormal;
     inst.function = std::string(kGetPCISelPrefix) +
                     std::to_string(inst.operands.front().size);

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -788,7 +788,8 @@ static void DecodeOperand(Instruction &inst, const xed_decoded_inst_t *xedd,
   }
 }
 
-static uint64_t BytesToBits(const uint8_t *bytes) {
+static uint64_t BytesToCallBits(const uint8_t *bytes) {
+  // The pattern we're looking for is 5 bytes long.
   uint64_t bits = 0;
   bits = (bits << 8) | static_cast<uint32_t>(bytes[0]);
   bits = (bits << 8) | static_cast<uint32_t>(bytes[1]);
@@ -801,13 +802,13 @@ static uint64_t BytesToBits(const uint8_t *bytes) {
 static bool TryDecodeIdioms(Instruction &inst) {
   // Check for CALL+POP idiom used to retrieve PC.
   if (inst.bytes.size() == 6) {
-    const auto call_pc = inst.pc;
     const auto bytes = reinterpret_cast<const uint8_t *>(inst.bytes.data());
-    const auto bits1 = BytesToBits(bytes);
+    const auto call_pc = inst.pc;
+    const auto call_bits = BytesToCallBits(bytes);
 
     // Check that we have a CALL pointing one instruction ahead of where we are
     // now.
-    if (bits1 != 0xe800000000) {
+    if (call_bits != 0xe800000000) {
       return false;
     }
 

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -852,7 +852,7 @@ static bool TryDecodeGetPCIdiom(Instruction &inst) {
 
 static bool TryDecodeIdioms(Instruction &inst) {
   if (TryDecodeGetPCIdiom(inst)) {
-    return inst.IsValid();
+    return true;
   }
   return false;
 }

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -821,6 +821,7 @@ static bool TryDecodeGetPCIdiom(Instruction &inst) {
       << "Unexpected number of POP operands, expected=1, got="
       << pop_inst.operands.size();
   inst.operands = std::move(pop_inst.operands);
+  inst.bytes.resize(call_size + pop_inst.bytes.size());
 
   // The second operand is the address of the POP instruction.
   inst.operands.emplace_back();

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -824,7 +824,9 @@ static bool TryDecodeIdioms(Instruction &inst) {
 
     // The first operand should be the register that we're popping into. Just
     // take the operand from the POP instruction.
-    assert(pop_inst.operands.size() == 1);
+    CHECK(pop_inst.operands.size() == 1)
+        << "Unexpected number of POP operands, expected=1, got="
+        << pop_inst.operands.size();
     inst.operands = std::move(pop_inst.operands);
 
     // The second operand is the address of the POP instruction.
@@ -833,10 +835,10 @@ static bool TryDecodeIdioms(Instruction &inst) {
     addr_op.type = Operand::kTypeAddressExpression;
     auto *pc_reg =
         inst.EmplaceRegister(inst.arch->ProgramCounterRegisterName());
-    assert(pc_reg);
+    CHECK(pc_reg);
     auto *pc_offset = inst.EmplaceConstant(
         llvm::ConstantInt::get(inst.arch->AddressType(), 5));
-    assert(pc_offset);
+    CHECK(pc_offset);
     addr_op.expr =
         inst.EmplaceBinaryOp(llvm::Instruction::Add, pc_reg, pc_offset);
 

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -831,7 +831,8 @@ static bool TryDecodeIdioms(Instruction &inst) {
     inst.operands.emplace_back();
     auto &addr_op = inst.operands.back();
     addr_op.type = Operand::kTypeAddressExpression;
-    auto *pc_reg = inst.EmplaceRegister("EIP");
+    auto *pc_reg =
+        inst.EmplaceRegister(inst.arch->ProgramCounterRegisterName());
     assert(pc_reg);
     auto *pc_offset = inst.EmplaceConstant(
         llvm::ConstantInt::get(inst.arch->AddressType(), 5));

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -788,7 +788,7 @@ static void DecodeOperand(Instruction &inst, const xed_decoded_inst_t *xedd,
   }
 }
 
-static unsigned char GET_PC_IDIOM_CALL[] = {0xE8, 0x00, 0x00, 0x00, 0x00};
+static const unsigned char GET_PC_IDIOM_CALL[] = {0xE8, 0x00, 0x00, 0x00, 0x00};
 
 static bool TryDecodeGetPCIdiom(Instruction &inst) {
   // Check for CALL+POP idiom used to retrieve PC.

--- a/lib/Arch/X86/Runtime/CMakeLists.txt
+++ b/lib/Arch/X86/Runtime/CMakeLists.txt
@@ -88,6 +88,7 @@ function(add_runtime_helper target_name address_bit_size enable_avx enable_avx51
     "${REMILL_LIB_DIR}/Arch/X86/Semantics/X87.cpp"
     "${REMILL_LIB_DIR}/Arch/X86/Semantics/COND_BR.cpp"
     "${REMILL_LIB_DIR}/Arch/X86/Semantics/INTERRUPT.cpp"
+    "${REMILL_LIB_DIR}/Arch/X86/Semantics/GET_PC.cpp"
   )
 endfunction()
 

--- a/lib/Arch/X86/Runtime/Instructions.cpp
+++ b/lib/Arch/X86/Runtime/Instructions.cpp
@@ -211,6 +211,7 @@ DEF_HELPER(SquareRoot32, float32_t src_float)->float32_t {
 #include "lib/Arch/X86/Semantics/DECIMAL.cpp"
 #include "lib/Arch/X86/Semantics/FLAGOP.cpp"
 #include "lib/Arch/X86/Semantics/FMA.cpp"
+#include "lib/Arch/X86/Semantics/GET_PC.cpp"
 #include "lib/Arch/X86/Semantics/INTERRUPT.cpp"
 #include "lib/Arch/X86/Semantics/IO.cpp"
 #include "lib/Arch/X86/Semantics/LOGICAL.cpp"

--- a/lib/Arch/X86/Semantics/GET_PC.cpp
+++ b/lib/Arch/X86/Semantics/GET_PC.cpp
@@ -25,7 +25,7 @@ DEF_SEM(GET_PC, D dst, S1 src1) {
   return memory;
 }
 
-DEF_ISEL(GET_PC_16) = GET_PC<M16W, R32>;
-DEF_ISEL(GET_PC_32) = GET_PC<M32W, R32>;
+DEF_ISEL(GET_PC_16) = GET_PC<R16W, R32>;
+DEF_ISEL(GET_PC_32) = GET_PC<R32W, R32>;
 
 }  // namespace

--- a/lib/Arch/X86/Semantics/GET_PC.cpp
+++ b/lib/Arch/X86/Semantics/GET_PC.cpp
@@ -20,7 +20,7 @@ namespace {
 
 template <typename D, typename S1>
 DEF_SEM(GET_PC, D dst, S1 src1) {
-  addr_t pc = Read(dst);
+  addr_t pc = Read(src1);
   Write(dst, Read(ReadPtr<D>(pc)));
   return memory;
 }

--- a/lib/Arch/X86/Semantics/GET_PC.cpp
+++ b/lib/Arch/X86/Semantics/GET_PC.cpp
@@ -16,13 +16,12 @@
 
 #pragma once
 
-template <typename D>
-DEF_SEM(GET_PC, D dst) {
-  addr_t pc = Read(REG_PC);
+template <typename D, typename S1>
+DEF_SEM(GET_PC, D dst, S1 src1) {
+  addr_t pc = Read(dst);
   Write(dst, Read(ReadPtr<D>(pc)));
   return memory;
 }
 
-DEF_ISEL(GET_PC_16) = GET_PC<M16W>;
-DEF_ISEL(GET_PC_32) = GET_PC<M32W>;
-DEF_ISEL(GET_PC_64) = GET_PC<M64W>;
+DEF_ISEL(GET_PC_16) = GET_PC<M16W, R32>;
+DEF_ISEL(GET_PC_32) = GET_PC<M32W, R32>;

--- a/lib/Arch/X86/Semantics/GET_PC.cpp
+++ b/lib/Arch/X86/Semantics/GET_PC.cpp
@@ -16,6 +16,8 @@
 
 #pragma once
 
+namespace {
+
 template <typename D, typename S1>
 DEF_SEM(GET_PC, D dst, S1 src1) {
   addr_t pc = Read(dst);
@@ -25,3 +27,5 @@ DEF_SEM(GET_PC, D dst, S1 src1) {
 
 DEF_ISEL(GET_PC_16) = GET_PC<M16W, R32>;
 DEF_ISEL(GET_PC_32) = GET_PC<M32W, R32>;
+
+}  // namespace

--- a/lib/Arch/X86/Semantics/GET_PC.cpp
+++ b/lib/Arch/X86/Semantics/GET_PC.cpp
@@ -1,0 +1,28 @@
+/*
+ * Copyright (c) 2022 Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+template <typename D>
+DEF_SEM(GET_PC, D dst) {
+  addr_t pc = Read(REG_PC);
+  Write(dst, Read(ReadPtr<D>(pc)));
+  return memory;
+}
+
+DEF_ISEL(GET_PC_16) = GET_PC<M16W>;
+DEF_ISEL(GET_PC_32) = GET_PC<M32W>;
+DEF_ISEL(GET_PC_64) = GET_PC<M64W>;

--- a/lib/BC/ABI.cpp
+++ b/lib/BC/ABI.cpp
@@ -28,6 +28,7 @@ const std::string_view kBranchTakenVariableName = "BRANCH_TAKEN";
 const std::string_view kInvalidInstructionISelName = "INVALID_INSTRUCTION";
 const std::string_view kUnsupportedInstructionISelName =
     "UNSUPPORTED_INSTRUCTION";
+const std::string_view kGetPCISelName = "GET_PC";
 
 const std::string_view kIgnoreNextPCVariableName = "IGNORE_NEXT_PC";
 

--- a/lib/BC/ABI.cpp
+++ b/lib/BC/ABI.cpp
@@ -28,7 +28,7 @@ const std::string_view kBranchTakenVariableName = "BRANCH_TAKEN";
 const std::string_view kInvalidInstructionISelName = "INVALID_INSTRUCTION";
 const std::string_view kUnsupportedInstructionISelName =
     "UNSUPPORTED_INSTRUCTION";
-const std::string_view kGetPCISelName = "GET_PC";
+const std::string_view kGetPCISelPrefix = "GET_PC_";
 
 const std::string_view kIgnoreNextPCVariableName = "IGNORE_NEXT_PC";
 


### PR DESCRIPTION
This is an initial attempt at implementing the CALL+POP idiom that occurs in x86 code to assign the PC to a register.