### PR TITLE
Fix typo when parsing z3 version from headers

### DIFF
--- a/cmake/modules/FindZ3.cmake
+++ b/cmake/modules/FindZ3.cmake
@@ -81,7 +81,7 @@ if(NOT Z3_VERSION_STRING AND (CMAKE_CROSSCOMPILING AND
 
   file(STRINGS "${Z3_INCLUDE_DIR}/z3_version.h"
        z3_version_str REGEX "^#define[\t ]+Z3_BUILD_NUMBER[\t ]+.*")
-  string(REGEX REPLACE "^.*Z3_BUILD_VERSION[\t ]+([0-9]).*$" "\\1"
+  string(REGEX REPLACE "^.*Z3_BUILD_NUMBER[\t ]+([0-9]).*$" "\\1"
          Z3_BUILD "${z3_version_str}")
 
   set(Z3_VERSION_STRING ${Z3_MAJOR}.${Z3_MINOR}.${Z3_BUILD})


### PR DESCRIPTION
should be Z3_BUILD_NUMBER instead of Z3_BUILD_VERSION
see: https://github.com/llvm/llvm-project/blob/dc07d2c91dfd7f14991d07ef1df5f1f0b19b306d/llvm/cmake/modules/FindZ3.cmake#L103