### PR TITLE
Ian/instruction carry lifter

### DIFF
--- a/bin/lift/Lift.cpp
+++ b/bin/lift/Lift.cpp
@@ -269,7 +269,7 @@ int main(int argc, char *argv[]) {
 
   auto inst_lifter = arch->DefaultLifter(intrinsics);
 
-  remill::TraceLifter trace_lifter(*inst_lifter.get(), manager);
+  remill::TraceLifter trace_lifter(arch.get(), manager);
 
   // Lift all discoverable traces starting from `--entry_address` into
   // `module`.

--- a/include/remill/Arch/Arch.h
+++ b/include/remill/Arch/Arch.h
@@ -29,6 +29,7 @@
 #include <llvm/IR/DataLayout.h>
 #include <llvm/IR/IRBuilder.h>
 #include <remill/BC/InstructionLifter.h>
+#include <remill/BC/IntrinsicTable.h>
 
 #pragma clang diagnostic pop
 
@@ -199,6 +200,8 @@ class Arch {
   // null pointer will be returned.
   virtual llvm::StructType *RegisterWindowType(void) const = 0;
 
+
+  virtual const IntrinsicTable *GetInstrinsicTable(void) const = 0;
 
   virtual unsigned RegMdID(void) const = 0;
 

--- a/include/remill/Arch/Arch.h
+++ b/include/remill/Arch/Arch.h
@@ -260,9 +260,9 @@ class Arch {
   void PrepareModuleDataLayout(llvm::Module *mod) const;
 
 
-  // TODO(Ian): This is kinda messy but only an arch currently knows if it is
-  //            sleigh or not and sleigh needs different lifting context etc.
-  virtual InstructionLifter::LifterPtr
+  // A default lifter does not know how to lift instructions. The default lifter allows
+  // the user to perform instruction/context independent lifting operations.
+  virtual OperandLifter::OpLifterPtr
   DefaultLifter(const remill::IntrinsicTable &intrinsics) const = 0;
 
   inline void

--- a/include/remill/Arch/ArchBase.h
+++ b/include/remill/Arch/ArchBase.h
@@ -33,6 +33,11 @@ struct Register;
 
 // Internal base architecture for all Remill-internal architectures.
 class ArchBase : public remill::Arch {
+ protected:
+  virtual bool ArchDecodeInstruction(uint64_t address,
+                                     std::string_view instr_bytes,
+                                     Instruction &inst) const = 0;
+
  public:
   using ArchPtr = std::unique_ptr<const Arch>;
 
@@ -68,8 +73,9 @@ class ArchBase : public remill::Arch {
 
   unsigned RegMdID(void) const final;
 
-  // TODO(Ian): This is kinda messy but only an arch currently knows if it is
-  //            sleigh or not and sleigh needs different lifting context etc.
+  virtual bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                                 Instruction &inst) const override;
+
   OperandLifter::OpLifterPtr
   DefaultLifter(const remill::IntrinsicTable &intrinsics) const override;
 

--- a/include/remill/Arch/ArchBase.h
+++ b/include/remill/Arch/ArchBase.h
@@ -64,6 +64,8 @@ class ArchBase : public remill::Arch {
   // Return information about a register, given its name.
   const Register *RegisterByName(std::string_view name) const final;
 
+  const IntrinsicTable *GetInstrinsicTable(void) const final;
+
   unsigned RegMdID(void) const final;
 
   // TODO(Ian): This is kinda messy but only an arch currently knows if it is
@@ -103,6 +105,7 @@ class ArchBase : public remill::Arch {
   mutable std::vector<std::unique_ptr<Register>> registers;
   mutable std::vector<const Register *> reg_by_offset;
   mutable std::unordered_map<std::string, const Register *> reg_by_name;
+  mutable std::unique_ptr<IntrinsicTable> instrinsics{nullptr};
 };
 
 }  // namespace remill

--- a/include/remill/Arch/ArchBase.h
+++ b/include/remill/Arch/ArchBase.h
@@ -70,7 +70,7 @@ class ArchBase : public remill::Arch {
 
   // TODO(Ian): This is kinda messy but only an arch currently knows if it is
   //            sleigh or not and sleigh needs different lifting context etc.
-  InstructionLifter::LifterPtr
+  OperandLifter::OpLifterPtr
   DefaultLifter(const remill::IntrinsicTable &intrinsics) const override;
 
   // Get the state pointer and various other types from the `llvm::LLVMContext`

--- a/include/remill/Arch/Instruction.h
+++ b/include/remill/Arch/Instruction.h
@@ -354,6 +354,8 @@ class Instruction {
 
   const InstructionLifter::LifterPtr &GetLifter();
 
+  void SetLifter(InstructionLifter::LifterPtr lifter);
+
  private:
   InstructionLifter::LifterPtr lifter;
   static constexpr auto kMaxNumExpr = 64u;

--- a/include/remill/Arch/Instruction.h
+++ b/include/remill/Arch/Instruction.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <remill/BC/InstructionLifter.h>
+
 #include <string>
 #include <variant>
 #include <vector>
@@ -349,7 +351,11 @@ class Instruction {
   Operand &EmplaceOperand(const Operand::ShiftRegister &op);
   Operand &EmplaceOperand(const Operand::Address &op);
 
+
+  const InstructionLifter::LifterPtr &GetLifter();
+
  private:
+  InstructionLifter::LifterPtr lifter;
   static constexpr auto kMaxNumExpr = 64u;
   OperandExpression exprs[kMaxNumExpr];
   unsigned next_expr_index{0};

--- a/include/remill/BC/InstructionLifter.h
+++ b/include/remill/BC/InstructionLifter.h
@@ -56,7 +56,7 @@ enum LiftStatus {
 // is called with the appropriate arguments.
 class InstructionLifter {
  public:
-  using LifterPtr = std::unique_ptr<InstructionLifter>;
+  using LifterPtr = std::shared_ptr<InstructionLifter>;
 
   virtual ~InstructionLifter(void);
 

--- a/include/remill/BC/TraceLifter.h
+++ b/include/remill/BC/TraceLifter.h
@@ -86,10 +86,10 @@ class TraceLifter {
  public:
   ~TraceLifter(void);
 
-  inline TraceLifter(InstructionLifter &inst_lifter_, TraceManager &manager_)
-      : TraceLifter(&inst_lifter_, &manager_) {}
+  inline TraceLifter(const Arch *arch_, TraceManager &manager_)
+      : TraceLifter(arch_, &manager_) {}
 
-  TraceLifter(InstructionLifter *inst_lifter_, TraceManager *manager_);
+  TraceLifter(const Arch *arch_, TraceManager *manager_);
 
   static void NullCallback(uint64_t, llvm::Function *);
 

--- a/lib/Arch/AArch32/Arch.h
+++ b/lib/Arch/AArch32/Arch.h
@@ -26,8 +26,8 @@ class AArch32Arch final : public AArch32ArchBase {
 
   virtual ~AArch32Arch(void);
 
-  bool DecodeInstruction(uint64_t address, std::string_view inst_bytes,
-                         Instruction &inst) const override;
+  bool ArchDecodeInstruction(uint64_t address, std::string_view inst_bytes,
+                             Instruction &inst) const override;
 
  private:
   AArch32Arch(void) = delete;

--- a/lib/Arch/AArch64/Arch.cpp
+++ b/lib/Arch/AArch64/Arch.cpp
@@ -120,8 +120,8 @@ class AArch64Arch final : public ArchBase {
   std::string_view ProgramCounterRegisterName(void) const final;
 
   // Decode an instruction.
-  bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
-                         Instruction &inst) const final;
+  bool ArchDecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                             Instruction &inst) const final;
 
   // Align/Minimum/Maximum number of bytes in an instruction.
   uint64_t MinInstructionAlign(void) const final;
@@ -1212,9 +1212,9 @@ std::string_view AArch64Arch::ProgramCounterRegisterName(void) const {
   return "PC";
 }
 
-bool AArch64Arch::DecodeInstruction(uint64_t address,
-                                    std::string_view inst_bytes,
-                                    Instruction &inst) const {
+bool AArch64Arch::ArchDecodeInstruction(uint64_t address,
+                                        std::string_view inst_bytes,
+                                        Instruction &inst) const {
 
   aarch64::InstData dinst = {};
   auto bytes = reinterpret_cast<const uint8_t *>(inst_bytes.data());

--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -850,9 +850,9 @@ const IntrinsicTable *ArchBase::GetInstrinsicTable(void) const {
   return this->instrinsics.get();
 }
 
-InstructionLifter::LifterPtr
+OperandLifter::OpLifterPtr
 ArchBase::DefaultLifter(const remill::IntrinsicTable &intrinsics) const {
-  return std::make_unique<InstructionLifter>(this, intrinsics);
+  return std::make_shared<InstructionLifter>(this, intrinsics);
 }
 
 }  // namespace remill

--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -857,13 +857,9 @@ ArchBase::DefaultLifter(const remill::IntrinsicTable &intrinsics) const {
 
 bool ArchBase::DecodeInstruction(uint64_t address, std::string_view instr_bytes,
                                  Instruction &inst) const {
-  auto res = this->ArchDecodeInstruction(address, instr_bytes, inst);
-
-  if (res) {
-    inst.SetLifter(std::make_unique<remill::InstructionLifter>(
-        this, this->GetInstrinsicTable()));
-  }
-  return res;
+  inst.SetLifter(std::make_unique<remill::InstructionLifter>(
+      this, this->GetInstrinsicTable()));
+  return this->ArchDecodeInstruction(address, instr_bytes, inst);
 }
 
 }  // namespace remill

--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -842,6 +842,12 @@ void ArchBase::InitFromSemanticsModule(llvm::Module *module) const {
   reg_md_id = context->getMDKindID("remill_register");
 
   CHECK(!reg_by_name.empty());
+
+  this->instrinsics.reset(new IntrinsicTable(module));
+}
+
+const IntrinsicTable *ArchBase::GetInstrinsicTable(void) const {
+  return this->instrinsics.get();
 }
 
 InstructionLifter::LifterPtr

--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -855,4 +855,15 @@ ArchBase::DefaultLifter(const remill::IntrinsicTable &intrinsics) const {
   return std::make_shared<InstructionLifter>(this, intrinsics);
 }
 
+bool ArchBase::DecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                                 Instruction &inst) const {
+  auto res = this->ArchDecodeInstruction(address, instr_bytes, inst);
+
+  if (res) {
+    inst.SetLifter(std::make_unique<remill::InstructionLifter>(
+        this, this->GetInstrinsicTable()));
+  }
+  return res;
+}
+
 }  // namespace remill

--- a/lib/Arch/Instruction.cpp
+++ b/lib/Arch/Instruction.cpp
@@ -797,4 +797,8 @@ const InstructionLifter::LifterPtr &Instruction::GetLifter() {
   return this->lifter;
 }
 
+void Instruction::SetLifter(InstructionLifter::LifterPtr lifter) {
+  lifter.swap(lifter);
+}
+
 }  // namespace remill

--- a/lib/Arch/Instruction.cpp
+++ b/lib/Arch/Instruction.cpp
@@ -797,8 +797,8 @@ const InstructionLifter::LifterPtr &Instruction::GetLifter() {
   return this->lifter;
 }
 
-void Instruction::SetLifter(InstructionLifter::LifterPtr lifter) {
-  lifter.swap(lifter);
+void Instruction::SetLifter(InstructionLifter::LifterPtr lifter_) {
+  lifter.swap(lifter_);
 }
 
 }  // namespace remill

--- a/lib/Arch/Instruction.cpp
+++ b/lib/Arch/Instruction.cpp
@@ -793,4 +793,8 @@ std::string Instruction::Serialize(void) const {
   return ss.str();
 }
 
+const InstructionLifter::LifterPtr &Instruction::GetLifter() {
+  return this->lifter;
+}
+
 }  // namespace remill

--- a/lib/Arch/SPARC32/Arch.cpp
+++ b/lib/Arch/SPARC32/Arch.cpp
@@ -178,8 +178,8 @@ class SPARC32Arch final : public ArchBase {
   llvm::DataLayout DataLayout(void) const final;
 
   // Decode an instruction.
-  bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
-                         Instruction &inst) const final;
+  bool ArchDecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                             Instruction &inst) const final;
 
   // Returns `true` if memory access are little endian byte ordered.
   bool MemoryAccessIsLittleEndian(void) const final {
@@ -468,9 +468,9 @@ bool SPARC32Arch::NextInstructionIsDelayed(const Instruction &inst,
 }
 
 // Decode an instruction.
-bool SPARC32Arch::DecodeInstruction(uint64_t address,
-                                    std::string_view inst_bytes,
-                                    Instruction &inst) const {
+bool SPARC32Arch::ArchDecodeInstruction(uint64_t address,
+                                        std::string_view inst_bytes,
+                                        Instruction &inst) const {
   inst.pc = address;
   inst.arch_name = arch_name;
   inst.sub_arch_name = arch_name;

--- a/lib/Arch/SPARC64/Arch.cpp
+++ b/lib/Arch/SPARC64/Arch.cpp
@@ -86,8 +86,8 @@ class SPARC64Arch final : public ArchBase {
   llvm::DataLayout DataLayout(void) const final;
 
   // Decode an instruction.
-  bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
-                         Instruction &inst) const final;
+  bool ArchDecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                             Instruction &inst) const final;
 
   // Returns `true` if memory access are little endian byte ordered.
   bool MemoryAccessIsLittleEndian(void) const final {
@@ -440,9 +440,9 @@ bool SPARC64Arch::NextInstructionIsDelayed(const Instruction &inst,
 }
 
 // Decode an instruction.
-bool SPARC64Arch::DecodeInstruction(uint64_t address,
-                                    std::string_view inst_bytes,
-                                    Instruction &inst) const {
+bool SPARC64Arch::ArchDecodeInstruction(uint64_t address,
+                                        std::string_view inst_bytes,
+                                        Instruction &inst) const {
 
   inst.pc = address;
   inst.arch_name = arch_name;

--- a/lib/Arch/Sleigh/Arch.cpp
+++ b/lib/Arch/Sleigh/Arch.cpp
@@ -366,12 +366,19 @@ std::string CustomLoadImage::getArchType(void) const {
 void CustomLoadImage::adjustVma(long) {}
 
 
-bool SleighArch::ArchDecodeInstruction(uint64_t address,
-                                       std::string_view instr_bytes,
-                                       Instruction &inst) const {
+bool SleighArch::DecodeInstruction(uint64_t address,
+                                   std::string_view instr_bytes,
+                                   Instruction &inst) const {
   inst.SetLifter(
       std::make_shared<SleighLifter>(this, *this->GetInstrinsicTable()));
   assert(inst.GetLifter() != nullptr);
+
+  return this->ArchDecodeInstruction(address, instr_bytes, inst);
+}
+
+bool SleighArch::ArchDecodeInstruction(uint64_t address,
+                                       std::string_view instr_bytes,
+                                       Instruction &inst) const {
   // TODO(Ian): Since we dont control sleigh we probably need DecodeInsn to be non const?
   return const_cast<SleighArch *>(this)->DecodeInstructionImpl(
       address, instr_bytes, inst);

--- a/lib/Arch/Sleigh/Arch.cpp
+++ b/lib/Arch/Sleigh/Arch.cpp
@@ -366,12 +366,19 @@ std::string CustomLoadImage::getArchType(void) const {
 void CustomLoadImage::adjustVma(long) {}
 
 
-bool SleighArch::DecodeInstruction(uint64_t address,
-                                   std::string_view instr_bytes,
-                                   Instruction &inst) const {
+bool SleighArch::ArchDecodeInstruction(uint64_t address,
+                                       std::string_view instr_bytes,
+                                       Instruction &inst) const {
   // TODO(Ian): Since we dont control sleigh we probably need DecodeInsn to be non const?
-  return const_cast<SleighArch *>(this)->DecodeInstructionImpl(
+  auto res = const_cast<SleighArch *>(this)->DecodeInstructionImpl(
       address, instr_bytes, inst);
+
+  if (res) {
+    inst.SetLifter(
+        std::make_shared<SleighLifter>(this, *this->GetInstrinsicTable()));
+  }
+
+  return res;
 }
 
 SleighArch::SleighArch(llvm::LLVMContext *context_, OSName os_name_,

--- a/lib/Arch/Sleigh/Arch.cpp
+++ b/lib/Arch/Sleigh/Arch.cpp
@@ -369,16 +369,12 @@ void CustomLoadImage::adjustVma(long) {}
 bool SleighArch::ArchDecodeInstruction(uint64_t address,
                                        std::string_view instr_bytes,
                                        Instruction &inst) const {
+  inst.SetLifter(
+      std::make_shared<SleighLifter>(this, *this->GetInstrinsicTable()));
+  assert(inst.GetLifter() != nullptr);
   // TODO(Ian): Since we dont control sleigh we probably need DecodeInsn to be non const?
-  auto res = const_cast<SleighArch *>(this)->DecodeInstructionImpl(
+  return const_cast<SleighArch *>(this)->DecodeInstructionImpl(
       address, instr_bytes, inst);
-
-  if (res) {
-    inst.SetLifter(
-        std::make_shared<SleighLifter>(this, *this->GetInstrinsicTable()));
-  }
-
-  return res;
 }
 
 SleighArch::SleighArch(llvm::LLVMContext *context_, OSName os_name_,

--- a/lib/Arch/Sleigh/Arch.cpp
+++ b/lib/Arch/Sleigh/Arch.cpp
@@ -503,7 +503,7 @@ std::optional<int32_t> SingleInstructionSleighContext::oneInstruction(
 }
 
 
-InstructionLifter::LifterPtr
+OperandLifter::OpLifterPtr
 SleighArch::DefaultLifter(const remill::IntrinsicTable &intrinsics) const {
   return std::make_unique<SleighLifter>(this, intrinsics);
 }

--- a/lib/Arch/Sleigh/Arch.h
+++ b/lib/Arch/Sleigh/Arch.h
@@ -200,7 +200,7 @@ class SleighArch : virtual public ArchBase {
                          Instruction &inst) const override;
 
 
-  InstructionLifter::LifterPtr
+  OperandLifter::OpLifterPtr
   DefaultLifter(const remill::IntrinsicTable &intrinsics) const override;
 
 

--- a/lib/Arch/Sleigh/Arch.h
+++ b/lib/Arch/Sleigh/Arch.h
@@ -196,8 +196,12 @@ class SleighArch : virtual public ArchBase {
 
 
  public:
-  bool ArchDecodeInstruction(uint64_t address, std::string_view instr_bytes,
-                             Instruction &inst) const override;
+  virtual bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                                 Instruction &inst) const override;
+
+  virtual bool ArchDecodeInstruction(uint64_t address,
+                                     std::string_view instr_bytes,
+                                     Instruction &inst) const override;
 
 
   OperandLifter::OpLifterPtr

--- a/lib/Arch/Sleigh/Arch.h
+++ b/lib/Arch/Sleigh/Arch.h
@@ -196,8 +196,8 @@ class SleighArch : virtual public ArchBase {
 
 
  public:
-  bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
-                         Instruction &inst) const override;
+  bool ArchDecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                             Instruction &inst) const override;
 
 
   OperandLifter::OpLifterPtr

--- a/lib/Arch/X86/Arch.cpp
+++ b/lib/Arch/X86/Arch.cpp
@@ -787,8 +787,8 @@ class X86Arch final : public X86ArchBase {
   virtual ~X86Arch(void);
 
   // Decode an instruction.
-  bool DecodeInstruction(uint64_t address, std::string_view inst_bytes,
-                         Instruction &inst) const final;
+  bool ArchDecodeInstruction(uint64_t address, std::string_view inst_bytes,
+                             Instruction &inst) const final;
 
 
  private:
@@ -991,8 +991,9 @@ FillFusedCallPopRegOperands(Instruction &inst, unsigned address_size,
 }
 
 // Decode an instuction.
-bool X86Arch::DecodeInstruction(uint64_t address, std::string_view inst_bytes,
-                                Instruction &inst) const {
+bool X86Arch::ArchDecodeInstruction(uint64_t address,
+                                    std::string_view inst_bytes,
+                                    Instruction &inst) const {
 
   inst.pc = address;
   inst.arch = this;

--- a/lib/BC/InstructionLifter.cpp
+++ b/lib/BC/InstructionLifter.cpp
@@ -87,6 +87,7 @@ LiftStatus InstructionLifter::LiftIntoBlock(Instruction &arch_inst,
                                             llvm::BasicBlock *block,
                                             llvm::Value *state_ptr,
                                             bool is_delayed) {
+  LOG(INFO) << "In instructionlifter";
   llvm::Function *const func = block->getParent();
   llvm::Module *const module = func->getParent();
   llvm::Function *isel_func = nullptr;

--- a/lib/BC/SleighLifter.cpp
+++ b/lib/BC/SleighLifter.cpp
@@ -1286,7 +1286,6 @@ SleighLifter::LiftIntoInternalBlock(Instruction &inst, llvm::Module *target_mod,
 LiftStatus
 SleighLifter::LiftIntoBlock(Instruction &inst, llvm::BasicBlock *block,
                             llvm::Value *state_ptr, bool is_delayed) {
-
   if (!inst.IsValid()) {
     LOG(ERROR) << "Invalid function" << inst.Serialize();
     return kLiftedInvalidInstruction;

--- a/test_runner_lib/TestRunner.cpp
+++ b/test_runner_lib/TestRunner.cpp
@@ -253,7 +253,7 @@ LiftingTester::LiftInstructionFunction(std::string_view fname,
             << remill::LLVMThingToString(target_func->getType());
 
   if (remill::LiftStatus::kLiftedInstruction !=
-      this->lifter->LiftIntoBlock(insn, &target_func->getEntryBlock())) {
+      insn.GetLifter()->LiftIntoBlock(insn, &target_func->getEntryBlock())) {
     target_func->eraseFromParent();
     return std::nullopt;
   }

--- a/test_runner_lib/include/test_runner/TestRunner.h
+++ b/test_runner_lib/include/test_runner/TestRunner.h
@@ -160,7 +160,7 @@ class LiftingTester {
   std::shared_ptr<llvm::Module> semantics_module;
   remill::Arch::ArchPtr arch;
   std::unique_ptr<remill::IntrinsicTable> table;
-  remill::InstructionLifter::LifterPtr lifter;
+  remill::OperandLifter::OpLifterPtr lifter;
 
 
  public:

--- a/tests/AArch64/Lift.cpp
+++ b/tests/AArch64/Lift.cpp
@@ -130,8 +130,7 @@ extern "C" int main(int argc, char *argv[]) {
   auto module = remill::LoadArchSemantics(arch.get());
 
   remill::IntrinsicTable intrinsics(module.get());
-  remill::InstructionLifter inst_lifter(arch, intrinsics);
-  remill::TraceLifter trace_lifter(inst_lifter, manager);
+  remill::TraceLifter trace_lifter(arch.get(), manager);
 
   for (auto test : tests) {
     if (!trace_lifter.Lift(test->test_begin)) {

--- a/tests/X86/Lift.cpp
+++ b/tests/X86/Lift.cpp
@@ -130,8 +130,7 @@ extern "C" int main(int argc, char *argv[]) {
   auto module = remill::LoadArchSemantics(arch.get());
 
   remill::IntrinsicTable intrinsics(module.get());
-  remill::InstructionLifter inst_lifter(arch, intrinsics);
-  remill::TraceLifter trace_lifter(inst_lifter, manager);
+  remill::TraceLifter trace_lifter(arch.get(), manager);
 
   for (auto test : tests) {
     if (!trace_lifter.Lift(test->test_begin)) {


### PR DESCRIPTION
This PR limits the scope of Default lifters to only providing instruction independent lifting (ie. lifting registers). Instruction lifting is now held by the instruction itself. The decoder is then able to select the lifter based on instruction context. 