### PR TITLE
Fix Type Info for Register Variable GEPs

### DIFF
--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -311,6 +311,7 @@ void ArchBase::ForEachRegister(std::function<void(const Register *)> cb) const {
 // Return information about a register, given its name.
 const Register *ArchBase::RegisterByName(std::string_view name_) const {
   std::string name(name_.data(), name_.size());
+
   auto [curr_val_it, added] = reg_by_name.emplace(std::move(name), nullptr);
   if (added) {
     return nullptr;

--- a/lib/BC/InstructionLifter.cpp
+++ b/lib/BC/InstructionLifter.cpp
@@ -87,7 +87,6 @@ LiftStatus InstructionLifter::LiftIntoBlock(Instruction &arch_inst,
                                             llvm::BasicBlock *block,
                                             llvm::Value *state_ptr,
                                             bool is_delayed) {
-  LOG(INFO) << "In instructionlifter";
   llvm::Function *const func = block->getParent();
   llvm::Module *const module = func->getParent();
   llvm::Function *isel_func = nullptr;

--- a/lib/BC/InstructionLifter.cpp
+++ b/lib/BC/InstructionLifter.cpp
@@ -255,8 +255,13 @@ InstructionLifter::LoadRegAddress(llvm::BasicBlock *block,
 
   // It's already a variable in the function.
   const auto [var_ptr, var_ptr_type] = FindVarInFunction(func, reg_name_, true);
-  if (var_ptr && reg) {
-    reg_ptr_it->second = {var_ptr, reg->type};
+  if (var_ptr) {
+    auto ty = var_ptr_type;
+    //NOTE(Ian) for stuff like NEXT_PC existing in the block we arent going to have reg type info, im not sure i like pulling it from var_ptr_type regardles. Not sure what to do about it
+    if (reg) {
+      ty = reg->type;
+    }
+    reg_ptr_it->second = {var_ptr, ty};
     return reg_ptr_it->second;
   }
 

--- a/lib/BC/InstructionLifter.cpp
+++ b/lib/BC/InstructionLifter.cpp
@@ -250,10 +250,13 @@ InstructionLifter::LoadRegAddress(llvm::BasicBlock *block,
     return reg_ptr_it->second;
   }
 
+
+  auto reg = impl->arch->RegisterByName(reg_name_);
+
   // It's already a variable in the function.
   const auto [var_ptr, var_ptr_type] = FindVarInFunction(func, reg_name_, true);
-  if (var_ptr) {
-    reg_ptr_it->second = {var_ptr, var_ptr_type};
+  if (var_ptr && reg) {
+    reg_ptr_it->second = {var_ptr, reg->type};
     return reg_ptr_it->second;
   }
 
@@ -261,7 +264,7 @@ InstructionLifter::LoadRegAddress(llvm::BasicBlock *block,
   // right now. We'll try to be careful about the placement of the actual
   // indexing instructions so that they always follow the definition of the
   // state pointer, and thus are most likely to dominate all future uses.
-  if (auto reg = impl->arch->RegisterByName(reg_name_)) {
+  if (reg) {
     llvm::Value *reg_ptr = nullptr;
 
     // The state pointer is an argument.


### PR DESCRIPTION
This PR closes #618 by returning the type from the arches reg info rather than the inferred type of the GEP. 