### PR TITLE
Emit IR for `syscall` in addition to a `__remill_async_hyper_call`

### DIFF
--- a/include/remill/Arch/Runtime/HyperCall.h
+++ b/include/remill/Arch/Runtime/HyperCall.h
@@ -57,6 +57,10 @@ class SyncHyperCall {
     kAMD64SetControlReg4,
     kAMD64SetControlReg8,
 
+    kX86SysCall,
+    kX86SysEnter,
+    kX86SysExit,
+
     // TODO(pag): How to distinguish little- and big-endian?
     kAArch64EmulateInstruction = 0x200U,
     kAArch64Breakpoint,

--- a/lib/Arch/Runtime/HyperCall.cpp
+++ b/lib/Arch/Runtime/HyperCall.cpp
@@ -44,6 +44,20 @@
 
 Memory *__remill_sync_hyper_call(State &state, Memory *mem,
                                  SyncHyperCall::Name call) {
+
+#if REMILL_HYPERCALL_X86 || REMILL_HYPERCALL_AMD64
+  register unsigned int *rsp asm("rsp") = &state.gpr.rsp.dword;
+  register unsigned int *rbp asm("rbp") = &state.gpr.rbp.dword;
+  register unsigned int *r8 asm("r8") = &state.gpr.r8.dword;
+  register unsigned int *r9 asm("r9") = &state.gpr.r9.dword;
+  register unsigned int *r10 asm("r10") = &state.gpr.r10.dword;
+  register unsigned int *r11 asm("r11") = &state.gpr.r11.dword;
+  register unsigned int *r12 asm("r12") = &state.gpr.r12.dword;
+  register unsigned int *r13 asm("r13") = &state.gpr.r13.dword;
+  register unsigned int *r14 asm("r14") = &state.gpr.r14.dword;
+  register unsigned int *r15 asm("r15") = &state.gpr.r15.dword;
+#endif
+
   switch (call) {
 
 #if REMILL_HYPERCALL_X86 || REMILL_HYPERCALL_AMD64
@@ -129,12 +143,25 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
       mem = __remill_x86_set_segment_gs(mem);
       break;
 
-    case SyncHyperCall::kX86SysEnter: asm volatile("sysenter" : :); break;
+    case SyncHyperCall::kX86SysEnter:
+      asm volatile("sysenter"
+                   : "=a"(state.gpr.rax.dword)
+                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
+                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
+                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
+                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
+      break;
+
 
     case SyncHyperCall::kX86SysExit:
       asm volatile("sysexit"
-                   : "=c"(state.gpr.rcx.aword), "=d"(state.gpr.rdx.aword)
-                   :);
+                   : "=a"(state.gpr.rax.dword)
+                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
+                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
+                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
+                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
       break;
 
 #  if REMILL_HYPERCALL_X86
@@ -168,8 +195,9 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
                    : "=a"(state.gpr.rax.dword)
                    : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
                      "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
-                     "e"(state.gpr.rsi.dword), "f"(state.gpr.rdi.dword),
-                     "g"(state.gpr.rbp.dword));
+                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
+                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
       break;
 
 #  elif REMILL_HYPERCALL_AMD64
@@ -204,11 +232,12 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
 
     case SyncHyperCall::kX86SysCall:
       asm volatile("syscall"
-                   : "=a"(state.gpr.rax.qword)
-                   : "a"(state.gpr.rax.qword), "b"(state.gpr.rdi.qword),
-                     "c"(state.gpr.rsi.qword), "d"(state.gpr.rdx.qword),
-                     "e"(state.gpr.r10.qword), "f"(state.gpr.r8.qword),
-                     "g"(state.gpr.r9.qword));
+                   : "=a"(state.gpr.rax.dword)
+                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
+                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
+                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
+                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
       break;
 
 #  endif

--- a/lib/Arch/Runtime/HyperCall.cpp
+++ b/lib/Arch/Runtime/HyperCall.cpp
@@ -17,7 +17,7 @@
 #if defined(__x86_64__)
 #  include "remill/Arch/X86/Runtime/State.h"
 #  define REMILL_HYPERCALL_AMD64 1
-# elif defined(__i386__) || defined(_M_X86)
+#elif defined(__i386__) || defined(_M_X86)
 #  include "remill/Arch/X86/Runtime/State.h"
 #  define REMILL_HYPERCALL_X86 1
 #elif defined(__arm__)
@@ -155,6 +155,15 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
       mem = __remill_x86_set_control_reg_4(mem);
       break;
 
+    case SyncHyperCall::kX86SysCall:
+      asm volatile("syscall"
+                   : "=a"(state.gpr.rax.dword)
+                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
+                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
+                     "e"(state.gpr.rsi.dword), "f"(state.gpr.rdi.dword),
+                     "g"(state.gpr.rbp.dword));
+      break;
+
 #  elif REMILL_HYPERCALL_AMD64
 
     case SyncHyperCall::kAMD64SetDebugReg:
@@ -183,6 +192,15 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
 
     case SyncHyperCall::kAMD64SetControlReg8:
       mem = __remill_amd64_set_control_reg_8(mem);
+      break;
+
+    case SyncHyperCall::kX86SysCall:
+      asm volatile("syscall"
+                   : "=a"(state.gpr.rax.qword)
+                   : "a"(state.gpr.rax.qword), "b"(state.gpr.rdi.qword),
+                     "c"(state.gpr.rsi.qword), "d"(state.gpr.rdx.qword),
+                     "e"(state.gpr.r10.qword), "f"(state.gpr.r8.qword),
+                     "g"(state.gpr.r9.qword));
       break;
 
 #  endif

--- a/lib/Arch/Runtime/HyperCall.cpp
+++ b/lib/Arch/Runtime/HyperCall.cpp
@@ -45,17 +45,20 @@
 Memory *__remill_sync_hyper_call(State &state, Memory *mem,
                                  SyncHyperCall::Name call) {
 
-#if REMILL_HYPERCALL_X86 || REMILL_HYPERCALL_AMD64
-  register unsigned int *rsp asm("rsp") = &state.gpr.rsp.dword;
-  register unsigned int *rbp asm("rbp") = &state.gpr.rbp.dword;
-  register unsigned int *r8 asm("r8") = &state.gpr.r8.dword;
-  register unsigned int *r9 asm("r9") = &state.gpr.r9.dword;
-  register unsigned int *r10 asm("r10") = &state.gpr.r10.dword;
-  register unsigned int *r11 asm("r11") = &state.gpr.r11.dword;
-  register unsigned int *r12 asm("r12") = &state.gpr.r12.dword;
-  register unsigned int *r13 asm("r13") = &state.gpr.r13.dword;
-  register unsigned int *r14 asm("r14") = &state.gpr.r14.dword;
-  register unsigned int *r15 asm("r15") = &state.gpr.r15.dword;
+#if REMILL_HYPERCALL_X86
+  register uint32_t esp asm("esp") = state.gpr.rsp.dword;
+  register uint32_t ebp asm("ebp") = state.gpr.rbp.dword;
+#elif REMILL_HYPERCALL_AMD64
+  register uint64_t rsp asm("rsp") = state.gpr.rsp.qword;
+  register uint64_t rbp asm("rbp") = state.gpr.rbp.qword;
+  register uint64_t r8 asm("r8") = state.gpr.r8.qword;
+  register uint64_t r9 asm("r9") = state.gpr.r9.qword;
+  register uint64_t r10 asm("r10") = state.gpr.r10.qword;
+  register uint64_t r11 asm("r11") = state.gpr.r11.qword;
+  register uint64_t r12 asm("r12") = state.gpr.r12.qword;
+  register uint64_t r13 asm("r13") = state.gpr.r13.qword;
+  register uint64_t r14 asm("r14") = state.gpr.r14.qword;
+  register uint64_t r15 asm("r15") = state.gpr.r15.qword;
 #endif
 
   switch (call) {
@@ -143,27 +146,6 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
       mem = __remill_x86_set_segment_gs(mem);
       break;
 
-    case SyncHyperCall::kX86SysEnter:
-      asm volatile("sysenter"
-                   : "=a"(state.gpr.rax.dword)
-                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
-                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
-                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
-                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
-                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
-      break;
-
-
-    case SyncHyperCall::kX86SysExit:
-      asm volatile("sysexit"
-                   : "=a"(state.gpr.rax.dword)
-                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
-                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
-                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
-                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
-                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
-      break;
-
 #  if REMILL_HYPERCALL_X86
 
     case SyncHyperCall::kX86SetDebugReg:
@@ -192,12 +174,30 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
 
     case SyncHyperCall::kX86SysCall:
       asm volatile("syscall"
-                   : "=a"(state.gpr.rax.dword)
+                   : "=a"(state.gpr.rax.dword), "=r"(esp)
                    : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
                      "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
                      "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
-                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
-                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
+                     "r"(esp), "r"(ebp));
+      break;
+
+    case SyncHyperCall::kX86SysEnter:
+      asm volatile("sysenter"
+                   : "=a"(state.gpr.rax.dword), "=r"(esp)
+                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
+                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
+                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                     "r"(esp), "r"(ebp));
+      break;
+
+
+    case SyncHyperCall::kX86SysExit:
+      asm volatile("sysexit"
+                   : "=a"(state.gpr.rax.dword), "=r"(esp)
+                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
+                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
+                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                     "r"(esp), "r"(ebp));
       break;
 
 #  elif REMILL_HYPERCALL_AMD64
@@ -232,10 +232,31 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
 
     case SyncHyperCall::kX86SysCall:
       asm volatile("syscall"
-                   : "=a"(state.gpr.rax.dword)
-                   : "a"(state.gpr.rax.dword), "b"(state.gpr.rbx.dword),
-                     "c"(state.gpr.rcx.dword), "d"(state.gpr.rdx.dword),
-                     "S"(state.gpr.rsi.dword), "D"(state.gpr.rdi.dword),
+                   : "=a"(state.gpr.rax.qword), "=r"(rsp)
+                   : "a"(state.gpr.rax.qword), "b"(state.gpr.rbx.qword),
+                     "c"(state.gpr.rcx.qword), "d"(state.gpr.rdx.qword),
+                     "S"(state.gpr.rsi.qword), "D"(state.gpr.rdi.qword),
+                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
+                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
+      break;
+
+    case SyncHyperCall::kX86SysEnter:
+      asm volatile("sysenter"
+                   : "=a"(state.gpr.rax.qword), "=r"(rsp)
+                   : "a"(state.gpr.rax.qword), "b"(state.gpr.rbx.qword),
+                     "c"(state.gpr.rcx.qword), "d"(state.gpr.rdx.qword),
+                     "S"(state.gpr.rsi.qword), "D"(state.gpr.rdi.qword),
+                     "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
+                     "r"(r12), "r"(r13), "r"(r14), "r"(r15));
+      break;
+
+
+    case SyncHyperCall::kX86SysExit:
+      asm volatile("sysexit"
+                   : "=a"(state.gpr.rax.qword), "=r"(rsp)
+                   : "a"(state.gpr.rax.qword), "b"(state.gpr.rbx.qword),
+                     "c"(state.gpr.rcx.qword), "d"(state.gpr.rdx.qword),
+                     "S"(state.gpr.rsi.qword), "D"(state.gpr.rdi.qword),
                      "r"(rsp), "r"(rbp), "r"(r8), "r"(r9), "r"(r10), "r"(r11),
                      "r"(r12), "r"(r13), "r"(r14), "r"(r15));
       break;

--- a/lib/Arch/Runtime/HyperCall.cpp
+++ b/lib/Arch/Runtime/HyperCall.cpp
@@ -129,6 +129,14 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
       mem = __remill_x86_set_segment_gs(mem);
       break;
 
+    case SyncHyperCall::kX86SysEnter: asm volatile("sysenter" : :); break;
+
+    case SyncHyperCall::kX86SysExit:
+      asm volatile("sysexit"
+                   : "=c"(state.gpr.rcx.aword), "=d"(state.gpr.rdx.aword)
+                   :);
+      break;
+
 #  if REMILL_HYPERCALL_X86
 
     case SyncHyperCall::kX86SetDebugReg:

--- a/lib/Arch/X86/Runtime/CMakeLists.txt
+++ b/lib/Arch/X86/Runtime/CMakeLists.txt
@@ -35,6 +35,12 @@ function(add_runtime_helper target_name address_bit_size enable_avx enable_avx51
     set(required_cpp_standard "c++11")
   endif()
 
+  if (address_bit_size EQUAL 32)
+    set(x86_arch "i386")
+  else()
+    set(x86_arch "x86_64")
+  endif()
+
   add_runtime(${target_name}
     SOURCES ${X86RUNTIME_SOURCEFILES}
     ADDRESS_SIZE ${address_bit_size}
@@ -42,7 +48,7 @@ function(add_runtime_helper target_name address_bit_size enable_avx enable_avx51
     BCFLAGS "-std=${required_cpp_standard}"
     INCLUDEDIRECTORIES "${REMILL_INCLUDE_DIR}" "${REMILL_SOURCE_DIR}"
     INSTALLDESTINATION "${REMILL_INSTALL_SEMANTICS_DIR}"
-    ARCH x86_64
+    ARCH ${x86_arch}
 
     DEPENDENCIES
     "${REMILL_INCLUDE_DIR}/remill/Arch/Runtime/Float.h"

--- a/lib/Arch/X86/Semantics/SYSCALL.cpp
+++ b/lib/Arch/X86/Semantics/SYSCALL.cpp
@@ -17,21 +17,25 @@
 namespace {
 
 DEF_SEM(DoSYSCALL, IF_32BIT_ELSE(R32W, R64W)) {
+  memory = __remill_sync_hyper_call(state, memory, SyncHyperCall::kX86SysCall);
   HYPER_CALL = AsyncHyperCall::kX86SysCall;
   return memory;
 }
 
 DEF_SEM(DoSYSCALL_AMD, IF_32BIT_ELSE(R32W, R64W)) {
+  memory = __remill_sync_hyper_call(state, memory, SyncHyperCall::kX86SysCall);
   HYPER_CALL = AsyncHyperCall::kX86SysCall;
   return memory;
 }
 
 DEF_SEM(DoSYSENTER, IF_32BIT_ELSE(R32W, R64W)) {
+  memory = __remill_sync_hyper_call(state, memory, SyncHyperCall::kX86SysEnter);
   HYPER_CALL = AsyncHyperCall::kX86SysEnter;
   return memory;
 }
 
 DEF_SEM(DoSYSEXIT, IF_32BIT_ELSE(R32W, R64W)) {
+  memory = __remill_sync_hyper_call(state, memory, SyncHyperCall::kX86SysExit);
   HYPER_CALL = AsyncHyperCall::kX86SysExit;
   return memory;
 }


### PR DESCRIPTION
At the moment, we simply add a call to `__remill_async_hyper_call` to indicate a control flow change. We should also emit IR for the actual instruction.

I used these for reference:
https://www.cs.uaf.edu/2017/fall/cs301/lecture/11_17_syscall.html
https://www.felixcloutier.com/x86/syscall.html
https://www.felixcloutier.com/x86/sysenter
https://www.felixcloutier.com/x86/sysexit