### PR TITLE
Adding new type 'MV256W' and enabling AArch64 STP SIMD semantics.

### DIFF
--- a/include/remill/Arch/AArch64/Runtime/Types.h
+++ b/include/remill/Arch/AArch64/Runtime/Types.h
@@ -49,6 +49,7 @@ typedef MVnW<vec16_t> MV16W;
 typedef MVnW<vec32_t> MV32W;
 typedef MVnW<vec64_t> MV64W;
 typedef MVnW<vec128_t> MV128W;
+typedef MVnW<vec256_t> MV256W;
 
 typedef Mn<uint8_t> M8;
 typedef Mn<uint16_t> M16;

--- a/lib/Arch/AArch64/Semantics/DATAXFER.cpp
+++ b/lib/Arch/AArch64/Semantics/DATAXFER.cpp
@@ -72,15 +72,15 @@ DEF_SEM(STP_D, V64 src1, V64 src2, MV128W dst) {
 // remill/remill/Arch/Runtime/Operators.h:437:1: error: static_assert failed "Invalid value size for MVnW."
 // MAKE_MWRITEV(U, 128, dqwords, 128, uint128_t)
 
-// DEF_SEM(STP_Q, V128 src1, V128 src2, MV128W dst) {
-//   auto src1_vec = UReadV128(src1);
-//   auto src2_vec = UReadV128(src2);
-//   uint128v2_t tmp_vec = {};
-//   tmp_vec = UInsertV128(tmp_vec, 0, UExtractV128(src1_vec, 0));
-//   tmp_vec = UInsertV128(tmp_vec, 1, UExtractV128(src2_vec, 0));
-//   UWriteV128(dst, tmp_vec);
-//   return memory;
-// }
+DEF_SEM(STP_Q, V128 src1, V128 src2, MV256W dst) {
+  auto src1_vec = UReadV128(src1);
+  auto src2_vec = UReadV128(src2);
+  uint128v2_t tmp_vec = {};
+  tmp_vec = UInsertV128(tmp_vec, 0, UExtractV128(src1_vec, 0));
+  tmp_vec = UInsertV128(tmp_vec, 1, UExtractV128(src2_vec, 0));
+  UWriteV128(dst, tmp_vec);
+  return memory;
+}
 }  // namespace
 
 DEF_ISEL(STP_32_LDSTPAIR_PRE) = StorePairUpdateIndex32;
@@ -95,7 +95,7 @@ DEF_ISEL(STP_64_LDSTPAIR_OFF) = StorePair64;
 DEF_ISEL(STP_S_LDSTPAIR_OFF) = STP_S;
 DEF_ISEL(STP_D_LDSTPAIR_OFF) = STP_D;
 
-// DEF_ISEL(STP_Q_LDSTPAIR_OFF) = STP_Q;
+DEF_ISEL(STP_Q_LDSTPAIR_OFF) = STP_Q;
 
 namespace {
 


### PR DESCRIPTION
Hi!

I wanted to take a stab at adding support for the AArch64 **STP_Q_LDSTPAIR_OFF** semantics.

I prepared a preliminary patch, although there are some things that are not clear to me at the moment:

1. The old commented out code for the instruction was using the MV128W type, that I interpreted as "memory vector 128 bits write" type, although the actual semantics is writing a pair of 128 bits registers, hence why I added a MV256W type instead. Is this fine?
2. The generated code will result in a sequence of four 64 bits load instructions to read the pair of SIMD registers and then a sequence of four 64 bits store instructions to write the values to memory. There may be reasons to keep the 64 bits load/store instructions or to have instead two 128 bits load instructions and two 128 bits store instructions. What is the general rule in these cases?