### PR TITLE
Resolve semantics tests on AMD systems

### DIFF
--- a/tests/X86/Run.cpp
+++ b/tests/X86/Run.cpp
@@ -872,6 +872,11 @@ static void RunWithFlags(const test::TestInfo *info, Flags flags,
   lifted_state->x87.fxsave.fop = 0;
   native_state->x87.fxsave.fop = 0;
 
+  // On AMD systems, FXSAVE does not set x87 pointer registers.
+  // Even though we track `ip`, don't compare it.
+  lifted_state->x87.fxsave.ip = 0;
+  native_state->x87.fxsave.ip = 0;
+
   // Don't compare the tag words.
   lifted_state->x87.fxsave.ftw.flat = 0;
   native_state->x87.fxsave.ftw.flat = 0;


### PR DESCRIPTION
Unlike Intel, AMD has x87 pointer registers set to zero in most scenarios (cite [their manual](https://www.amd.com/system/files/TechDocs/26569.pdf), p. 26):
> FXSAVE does not save the x87 pointer registers (last instruction pointer, last data pointer, and last opcode), except in the relatively rare cases in which the exception-summary (ES) bit in the x87 status word is set to 1, indicating that an unmasked x87 exception has occurred.

As the x87 fop/dp are currently set to zero, additionally zeroing out ip allows lifted values to fully match native. This resolves #471.