### PR TITLE
Fix build with system LLVM

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -41,18 +41,13 @@ find_package(Z3 CONFIG REQUIRED)
 
 # LLVM
 find_package(LLVM CONFIG REQUIRED)
-llvm_map_components_to_libnames(llvm_libs
-  support core irreader
-  bitreader bitwriter
-  passes asmprinter
-  aarch64codegen aarch64asmparser
-  armcodegen armasmparser
-  interpreter mcjit
-  nvptxdesc
-  x86codegen x86asmparser
-  sparccodegen sparcasmparser
-  webassemblydesc)
-message(STATUS "LLVM Libraries: ${llvm_libs}")
+
+# https://github.com/JonathanSalwan/Triton/issues/1082#issuecomment-1030826696
+if(LLVM_LINK_LLVM_DYLIB)
+  set(llvm_libs LLVM)
+else()
+  set(llvm_libs ${LLVM_AVAILABLE_LIBS})
+endif()
 
 message(STATUS "Found LLVM ${LLVM_PACKAGE_VERSION}")
 message(STATUS "Using LLVMConfig.cmake in: ${LLVM_DIR}")
@@ -85,6 +80,7 @@ find_package(XED CONFIG REQUIRED)
 find_package(glog CONFIG REQUIRED)
 
 # Google gflags
+set(GFLAGS_USE_TARGET_NAMESPACE ON)
 find_package(gflags CONFIG REQUIRED)
 
 set(sleigh_ENABLE_TESTS OFF)
@@ -122,10 +118,10 @@ option(REMILL_BUILD_SPARC32_RUNTIME "Build the Runtime for SPARC32. Turn this of
 
 # add everything as public.
 add_library(remill_settings INTERFACE)
-
 target_include_directories(remill_settings INTERFACE
   $<BUILD_INTERFACE:${REMILL_INCLUDE_DIR}>
-  $<INSTALL_INTERFACE:include>)
+  $<INSTALL_INTERFACE:include>
+  $<BUILD_INTERFACE:${LLVM_INCLUDE_DIR}>)
 
 if(WIN32)
   # warnings and compiler settings

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,8 @@ set(sleigh_ADDITIONAL_PATCHES "${CMAKE_CURRENT_SOURCE_DIR}/patches/sleigh/x86-ia
 
 # GHIDRA SLEIGH
 FetchContent_Declare(sleigh
-  GIT_REPOSITORY https://github.com/lifting-bits/sleigh.git
-  GIT_TAG 9966017ca00fd910f7a27e62c1024c768fad5d51
+  GIT_REPOSITORY https://github.com/mrexodia/sleigh.git
+  GIT_TAG patch-author-9966017c
 )
 
 set(sleigh_BUILD_SUPPORT ON CACHE BOOL "" FORCE)


### PR DESCRIPTION
When using a vanilla LLVM there were some issues with the build (when using system libraries):

1. Certain libraries were missing, this is fixed by simply linking to all available LLVM libs
2. Without `GFLAGS_USE_TARGET_NAMESPACE` the target `gflags::gflags` does not exist, not sure what vcpkg is doing different there, perhaps an older version?
3. The LLVM include directories are not mentioned anywhere so remill fails to compile

These issues were found when trying a [superbuild](https://github.com/lifting-bits/cxx-common/issues/933#issuecomment-1323678496) without vcpkg.