### PR TITLE
Weaken remill check in utils to allow additional parameters

### DIFF
--- a/lib/BC/Util.cpp
+++ b/lib/BC/Util.cpp
@@ -239,9 +239,14 @@ FindVarInFunction(llvm::Function *function, std::string_view name_,
   return {nullptr, nullptr};
 }
 
+bool IsCompatibleStateFunction(llvm::Function *function) {
+  return function->arg_size() >= kNumBlockArgs;
+}
+
+
 // Find the machine state pointer.
 llvm::Value *LoadStatePointer(llvm::Function *function) {
-  CHECK(kNumBlockArgs == function->arg_size())
+  CHECK(IsCompatibleStateFunction(function))
       << "Invalid block-like function. Expected three arguments: state "
       << "pointer, program counter, and memory pointer in function "
       << function->getName().str();
@@ -254,7 +259,7 @@ llvm::Value *LoadStatePointer(llvm::Function *function) {
 
 // Return the memory pointer argument.
 llvm::Value *LoadMemoryPointerArg(llvm::Function *function) {
-  CHECK(kNumBlockArgs == function->arg_size())
+  CHECK(IsCompatibleStateFunction(function))
       << "Invalid block-like function. Expected three arguments: state "
       << "pointer, program counter, and memory pointer in function "
       << function->getName().str();
@@ -267,7 +272,7 @@ llvm::Value *LoadMemoryPointerArg(llvm::Function *function) {
 
 // Return the program counter argument.
 llvm::Value *LoadProgramCounterArg(llvm::Function *function) {
-  CHECK(kNumBlockArgs == function->arg_size())
+  CHECK(IsCompatibleStateFunction(function))
       << "Invalid block-like function. Expected three arguments: state "
       << "pointer, program counter, and memory pointer in function "
       << function->getName().str();

--- a/lib/BC/Util.cpp
+++ b/lib/BC/Util.cpp
@@ -239,14 +239,14 @@ FindVarInFunction(llvm::Function *function, std::string_view name_,
   return {nullptr, nullptr};
 }
 
-bool IsCompatibleStateFunction(llvm::Function *function) {
+bool HasRemillLiftedFunctionParams(llvm::Function *function) {
   return function->arg_size() >= kNumBlockArgs;
 }
 
 
 // Find the machine state pointer.
 llvm::Value *LoadStatePointer(llvm::Function *function) {
-  CHECK(IsCompatibleStateFunction(function))
+  CHECK(HasRemillLiftedFunctionParams(function))
       << "Invalid block-like function. Expected three arguments: state "
       << "pointer, program counter, and memory pointer in function "
       << function->getName().str();
@@ -259,7 +259,7 @@ llvm::Value *LoadStatePointer(llvm::Function *function) {
 
 // Return the memory pointer argument.
 llvm::Value *LoadMemoryPointerArg(llvm::Function *function) {
-  CHECK(IsCompatibleStateFunction(function))
+  CHECK(HasRemillLiftedFunctionParams(function))
       << "Invalid block-like function. Expected three arguments: state "
       << "pointer, program counter, and memory pointer in function "
       << function->getName().str();
@@ -272,7 +272,7 @@ llvm::Value *LoadMemoryPointerArg(llvm::Function *function) {
 
 // Return the program counter argument.
 llvm::Value *LoadProgramCounterArg(llvm::Function *function) {
-  CHECK(IsCompatibleStateFunction(function))
+  CHECK(HasRemillLiftedFunctionParams(function))
       << "Invalid block-like function. Expected three arguments: state "
       << "pointer, program counter, and memory pointer in function "
       << function->getName().str();


### PR DESCRIPTION
This PR per discussion on https://github.com/lifting-bits/remill/commit/51ed49f8cf4cbdef220ab473c653c2e33622d760, instead allows users to add additional parameters to state functions by weakening the check by default. 