### PR TITLE
Adds Missing Case in IntraProcTransferCollector to Avoid Looping on InstrExit

### DIFF
--- a/lib/BC/PcodeCFG.cpp
+++ b/lib/BC/PcodeCFG.cpp
@@ -56,6 +56,11 @@ struct IntraProcTransferCollector {
     targets.push_back(ex.target_block_index);
   }
 
+
+  void operator()(const InstrExit &ex) {
+    return;
+  }
+
   void operator()(const Exit &ex) {
     std::visit(*this, ex);
   }


### PR DESCRIPTION
There was a missing case in the visitor causing `void operator()(const Exit &ex)` to call itself  