### PR TITLE
Fix Linux AArch64 compilation for SPARC32 runtime

### DIFF
--- a/cmake/BCCompiler.cmake
+++ b/cmake/BCCompiler.cmake
@@ -178,6 +178,7 @@ function(add_runtime target_name)
     # The hyper call implementation contains inline assembly for each architecture so we'll need to
     # cross-compile for the runtime architecture.
     if(${source_file} STREQUAL ${hyper_call_source})
+      list(FILTER bc_flag_list EXCLUDE REGEX "--target=.*")
       set(target_decl "-target" "${arch}-none-eabi")
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")
       set(target_decl "-target" "x86_64-apple-macosx11.0.0")

--- a/cmake/BCCompiler.cmake
+++ b/cmake/BCCompiler.cmake
@@ -178,6 +178,9 @@ function(add_runtime target_name)
     # The hyper call implementation contains inline assembly for each architecture so we'll need to
     # cross-compile for the runtime architecture.
     if(${source_file} STREQUAL ${hyper_call_source})
+      # Some architectures add an explicit target for the host to successfully
+      # compile with 32 bits (like AArch64 to arm), however, we don't want that
+      # to interfere with the hyper call crosscompile
       list(FILTER bc_flag_list EXCLUDE REGEX "--target=.*")
       set(target_decl "-target" "${arch}-none-eabi")
     elseif(${CMAKE_SYSTEM_NAME} MATCHES "Darwin")

--- a/lib/Arch/AArch32/Runtime/CMakeLists.txt
+++ b/lib/Arch/AArch32/Runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(arm_runtime)
 
 set(ARMRUNTIME_SOURCEFILES

--- a/lib/Arch/AArch64/Runtime/CMakeLists.txt
+++ b/lib/Arch/AArch64/Runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(AARCH64_runtime)
 
 set(AARCH64RUNTIME_SOURCEFILES

--- a/lib/Arch/PPC/Runtime/CMakeLists.txt
+++ b/lib/Arch/PPC/Runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(ppc_runtime)
 
 set(PPCRUNTIME_SOURCEFILES

--- a/lib/Arch/SPARC32/Runtime/CMakeLists.txt
+++ b/lib/Arch/SPARC32/Runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(sparc32_runtime)
 
 set(SPARC32RUNTIME_SOURCEFILES

--- a/lib/Arch/SPARC64/Runtime/CMakeLists.txt
+++ b/lib/Arch/SPARC64/Runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(sparc64_runtime)
 
 set(SPARC64RUNTIME_SOURCEFILES

--- a/lib/Arch/X86/Runtime/CMakeLists.txt
+++ b/lib/Arch/X86/Runtime/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.2)
+cmake_minimum_required(VERSION 3.6)
 project(x86_runtime)
 
 set(X86RUNTIME_SOURCEFILES


### PR DESCRIPTION
Issue with conflicting compilation target(s).

Tests fail though.

```
Test project /app/builds/remill-build
    Start 1: small_diff_test
1/4 Test #1: small_diff_test ..................***Failed    0.78 sec
  0%|          | 0/1 [00:00<?, ?it/s]F20230510 16:26:03.200791 47053 InstructionLifter.cpp:651] Check failed: arg_type->isIntegerTy(impl->arch->address_size) Bad semantics function implementation for instruction at deadbe00. Integer constants that are smaller than the machine word size should be represented as machine word sized arguments to semantics functions.
*** Check failure stack trace: ***
    @     0xaaaae0483be8  google::LogMessage::SendToLog()
    @     0xaaaae0480580  google::LogMessage::Flush()
    @     0xaaaae0484200  google::LogMessageFatal::~LogMessageFatal()
    @     0xaaaae04991d0  remill::InstructionLifter::LiftImmediateOperand()
    @     0xaaaae04966d0  remill::InstructionLifter::LiftIntoBlock()
    @     0xaaaae049434c  test_runner::LiftingTester::LiftInstructionFunction()
    @     0xaaaae04946b0  test_runner::LiftingTester::LiftInstructionFunction()
    @     0xaaaae0473f44  DifferentialModuleBuilder::build()
    @     0xaaaae0472454  runTestCase()
    @     0xaaaae0473208  main
    @     0xffffa9be73fc  (unknown)
    @     0xffffa9be74cc  __libc_start_main
    @     0xaaaae0472030  _start
    @              (nil)  (unknown)
100%|██████████| 1/1 [00:00<00:00,  1.41it/s]
Ran 530 with 530 failing. Success rate of: 0.0

    Start 2: thumb-tests
2/4 Test #2: thumb-tests ......................   Passed    5.60 sec
    Start 3: ppc-tests
3/4 Test #3: ppc-tests ........................   Passed   10.93 sec
    Start 4: aarch64
Could not find executable /app/builds/remill-build/tests/AArch64/run-aarch64-tests
Looked in the following places:
/app/builds/remill-build/tests/AArch64/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Release/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Release/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Debug/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Debug/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/MinSizeRel/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/MinSizeRel/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/RelWithDebInfo/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/RelWithDebInfo/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Deployment/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Deployment/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Development/run-aarch64-tests
/app/builds/remill-build/tests/AArch64/Development/run-aarch64-tests
app/builds/remill-build/tests/AArch64/run-aarch64-tests
app/builds/remill-build/tests/AArch64/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Release/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Release/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Debug/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Debug/run-aarch64-tests
app/builds/remill-build/tests/AArch64/MinSizeRel/run-aarch64-tests
app/builds/remill-build/tests/AArch64/MinSizeRel/run-aarch64-tests
app/builds/remill-build/tests/AArch64/RelWithDebInfo/run-aarch64-tests
app/builds/remill-build/tests/AArch64/RelWithDebInfo/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Deployment/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Deployment/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Development/run-aarch64-tests
app/builds/remill-build/tests/AArch64/Development/run-aarch64-tests
Unable to find executable: /app/builds/remill-build/tests/AArch64/run-aarch64-tests
4/4 Test #4: aarch64 ..........................***Not Run   0.00 sec

50% tests passed, 2 tests failed out of 4

Total Test time (real) =  17.32 sec

The following tests FAILED:
          1 - small_diff_test (Failed)
          4 - aarch64 (Not Run)
```