### PR TITLE
Don't mark instruction as "invalid" when we can't determine a control flow category

### DIFF
--- a/lib/Arch/Sleigh/Arch.cpp
+++ b/lib/Arch/Sleigh/Arch.cpp
@@ -299,7 +299,9 @@ SleighDecoder::DecodeInstructionImpl(uint64_t address,
     LOG(ERROR) << "Failed to compute category for inst at " << std::hex
                << inst.pc;
     inst.flows = Instruction::InvalidInsn();
-    inst.category = Instruction::Category::kCategoryInvalid;
+    // Do not mark the instruction category as "invalid". Even if we can't determine a control flow
+    // category, we still want to attempt to lift this instruction.
+    inst.category = Instruction::Category::kCategoryNormal;
     return std::make_pair(inst.flows, std::nullopt);
   }
 


### PR DESCRIPTION
Do not merge! This is just a starting point for discussion.

At the moment, when we can't determine a control flow category (happens with instructions like `call`, `ret`, etc which have branching in the middle of their PCode on `DECOMPILE_MODE` or `didrestore`), we just skip lifting this instruction. This happens [here](https://github.com/lifting-bits/remill/blob/master/lib/BC/SleighLifter.cpp#L1729). I think that check needs to remain since we don't want to attempt to lift for a truly invalid instruction (i.e. we failed to even decode it). Therefore, the change needs to happen here so we categorise this situation differently.

This doesn't solve the problem since we now generate IR with conditional branching right in the middle of a basic block, meaning we start running into this:
```
E20230809 18:37:37.050169 2359682 Util.cpp:460] Error verifying function: Terminator found in the middle of a basic block!
```

@2over12 @Ninja3047 Did you have ideas on how to best handle this? This is a bit of an odd situation since the lifted PCode doesn't conform to a valid basic block anymore.