### PR TITLE
Fix Sleigh PPC Layout to Match Ghidra Spec

### DIFF
--- a/lib/Arch/Sleigh/PPCArch.cpp
+++ b/lib/Arch/Sleigh/PPCArch.cpp
@@ -106,7 +106,7 @@ class SleighPPCArch : public ArchBase {
   }
 
   llvm::DataLayout DataLayout(void) const override {
-    return llvm::DataLayout("e-m:e-p:32:32-i32:32-i64:64-f64:64-n32:64-S128");
+    return llvm::DataLayout("E-m:e-p:32:32-Fn32-i64:64-n32");
   }
 
   void PopulateRegisterTable(void) const override {


### PR DESCRIPTION
The layout here should roughly match the default we configure sleigh with. We at least need big endian for ppc_32_e200_be