### PR TITLE
[RFC][Sleigh] Add base implementation for MIPS (WIP)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,7 @@ set(REMILL_BUILD_SEMANTICS_DIR_AARCH64 "${CMAKE_CURRENT_BINARY_DIR}/lib/Arch/AAr
 set(REMILL_BUILD_SEMANTICS_DIR_SPARC32 "${CMAKE_CURRENT_BINARY_DIR}/lib/Arch/SPARC32/Runtime")
 set(REMILL_BUILD_SEMANTICS_DIR_SPARC64 "${CMAKE_CURRENT_BINARY_DIR}/lib/Arch/SPARC64/Runtime")
 set(REMILL_BUILD_SEMANTICS_DIR_PPC64_32ADDR "${CMAKE_CURRENT_BINARY_DIR}/lib/Arch/PPC/Runtime")
+set(REMILL_BUILD_SEMANTICS_DIR_MIPS64_32ADDR "${CMAKE_CURRENT_BINARY_DIR}/lib/Arch/MIPS/Runtime")
 set(REMILL_INCLUDE_DIR "${CMAKE_CURRENT_SOURCE_DIR}/include")
 set(REMILL_LIB_DIR "${CMAKE_CURRENT_SOURCE_DIR}/lib")
 
@@ -220,6 +221,7 @@ target_compile_definitions(remill_settings INTERFACE
   "REMILL_BUILD_SEMANTICS_DIR_SPARC32=\"${REMILL_BUILD_SEMANTICS_DIR_SPARC32}\""
   "REMILL_BUILD_SEMANTICS_DIR_SPARC64=\"${REMILL_BUILD_SEMANTICS_DIR_SPARC64}\""
   "REMILL_BUILD_SEMANTICS_DIR_PPC64_32ADDR=\"${REMILL_BUILD_SEMANTICS_DIR_PPC64_32ADDR}\""
+  "REMILL_BUILD_SEMANTICS_DIR_MIPS64_32ADDR=\"${REMILL_BUILD_SEMANTICS_DIR_MIPS64_32ADDR}\""
 )
 
 set(ghidra_patch_user "github-actions[bot]")
@@ -254,8 +256,17 @@ sleigh_compile(
   OUT_FILE "${sleigh_BINARY_DIR}/specfiles/Ghidra/Processors/PowerPC/data/languages/ppc_32_e200_be.sla"
 )
 
+sleigh_compile(
+  TARGET mips_be_vr4300_spec
+  COMPILER "${sleigh_compiler}"
+  SLASPEC "${ghidra-fork_SOURCE_DIR}/Ghidra/Processors/MIPS/data/languages/mips64be.slaspec"
+  LOG_FILE "${sleigh_BINARY_DIR}/sleighspecs/spec_build_logs/mips64be.sla.log"
+  OUT_FILE "${sleigh_BINARY_DIR}/specfiles/Ghidra/Processors/MIPS/data/languages/mips64be.sla"
+)
+
 add_custom_target(sleigh_custom_specs)
 add_dependencies(sleigh_custom_specs ppc_e200_spec)
+add_dependencies(sleigh_custom_specs mips_be_vr4300_spec)
 
 target_link_libraries(remill_settings INTERFACE
   ${llvm_libs}
@@ -317,6 +328,7 @@ if(REMILL_ENABLE_INSTALL_TARGET)
   )
 
   install(FILES "${sleigh_BINARY_DIR}/specfiles/Ghidra/Processors/PowerPC/data/languages/ppc_32_e200_be.sla" DESTINATION "${CMAKE_INSTALL_DATADIR}/sleigh/specfiles/Ghidra/Processors/PowerPC/data/languages/")
+  install(FILES "${sleigh_BINARY_DIR}/specfiles/Ghidra/Processors/MIPS/data/languages/mips64be.sla" DESTINATION "${CMAKE_INSTALL_DATADIR}/sleigh/specfiles/Ghidra/Processors/MIPS/data/languages/")
 
   configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake/remillConfig.cmake.in"

--- a/include/remill/Arch/Arch.h
+++ b/include/remill/Arch/Arch.h
@@ -357,6 +357,7 @@ class Arch {
   bool IsSPARC32(void) const;
   bool IsSPARC64(void) const;
   bool IsPPC(void) const;
+  bool IsMIPS(void) const;
 
   bool IsWindows(void) const;
   bool IsLinux(void) const;
@@ -435,6 +436,10 @@ class Arch {
 
   // Defined in `lib/Arch/Sleigh/PPCArch.cpp`
   static ArchPtr GetSleighPPC(llvm::LLVMContext *context, OSName os,
+                              ArchName arch_name);
+
+  // Defined in `lib/Arch/Sleigh/MIPSArch.cpp`
+  static ArchPtr GetSleighMIPS(llvm::LLVMContext *context, OSName os,
                               ArchName arch_name);
 
   // Defined in `lib/Arch/SPARC32/Arch.cpp`.

--- a/include/remill/Arch/MIPS/Runtime/State.h
+++ b/include/remill/Arch/MIPS/Runtime/State.h
@@ -1,0 +1,278 @@
+/*
+ * Copyright (c) 2022-present Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#pragma clang diagnostic push
+#pragma clang diagnostic fatal "-Wpadded"
+
+#include "remill/Arch/Runtime/State.h"
+
+#if !defined(INCLUDED_FROM_REMILL)
+#  include "remill/Arch/Runtime/Types.h"
+#endif
+
+struct Reg final {
+  union {
+    alignas(4) uint32_t dword;
+    alignas(8) uint64_t qword;
+  } __attribute__((packed));
+} __attribute__((packed));
+
+static_assert(sizeof(uint64_t) == sizeof(Reg), "Invalid packing of `Reg`.");
+static_assert(0 == __builtin_offsetof(Reg, dword),
+              "Invalid packing of `Reg::dword`.");
+
+static_assert(0 == __builtin_offsetof(Reg, qword),
+              "Invalid packing of `Reg::qword`.");
+
+// General Purpose Registers
+struct alignas(8) GPR final {
+  volatile uint64_t _0;
+  Reg zero;
+  volatile uint64_t _1;
+  Reg at;
+  volatile uint64_t _2;
+  Reg v0;
+  volatile uint64_t _3;
+  Reg v1;
+  volatile uint64_t _4;
+  Reg a0;
+  volatile uint64_t _5;
+  Reg a1;
+  volatile uint64_t _6;
+  Reg a2;
+  volatile uint64_t _7;
+  Reg a3;
+  volatile uint64_t _8;
+  Reg t0;
+  volatile uint64_t _9;
+  Reg t1;
+  volatile uint64_t _10;
+  Reg t2;
+  volatile uint64_t _11;
+  Reg t3;
+  volatile uint64_t _12;
+  Reg t4;
+  volatile uint64_t _13;
+  Reg t5;
+  volatile uint64_t _14;
+  Reg t6;
+  volatile uint64_t _15;
+  Reg t7;
+  volatile uint64_t _16;
+  Reg s0;
+  volatile uint64_t _17;
+  Reg s1;
+  volatile uint64_t _18;
+  Reg s2;
+  volatile uint64_t _19;
+  Reg s3;
+  volatile uint64_t _20;
+  Reg s4;
+  volatile uint64_t _21;
+  Reg s5;
+  volatile uint64_t _22;
+  Reg s6;
+  volatile uint64_t _23;
+  Reg s7;
+  volatile uint64_t _24;
+  Reg t8;
+  volatile uint64_t _25;
+  Reg t9;
+  volatile uint64_t _26;
+  Reg k0;
+  volatile uint64_t _27;
+  Reg k1;
+  volatile uint64_t _28;
+  Reg gp;
+  volatile uint64_t _29;
+  Reg sp;
+  volatile uint64_t _30;
+  Reg s8;
+  volatile uint64_t _31;
+  Reg ra;
+  volatile uint64_t _32;
+  Reg pc;
+
+} __attribute__((packed));
+
+static_assert(528 == sizeof(GPR), "Invalid structure packing of `GPR`.");
+
+// Floating Pointer Registers
+struct alignas(8) FPR final {
+  volatile uint64_t _0;
+  Reg f0;
+  volatile uint64_t _1;
+  Reg f1;
+  volatile uint64_t _2;
+  Reg f2;
+  volatile uint64_t _3;
+  Reg f3;
+  volatile uint64_t _4;
+  Reg f4;
+  volatile uint64_t _5;
+  Reg f5;
+  volatile uint64_t _6;
+  Reg f6;
+  volatile uint64_t _7;
+  Reg f7;
+  volatile uint64_t _8;
+  Reg f8;
+  volatile uint64_t _9;
+  Reg f9;
+  volatile uint64_t _10;
+  Reg f10;
+  volatile uint64_t _11;
+  Reg f11;
+  volatile uint64_t _12;
+  Reg f12;
+  volatile uint64_t _13;
+  Reg f13;
+  volatile uint64_t _14;
+  Reg f14;
+  volatile uint64_t _15;
+  Reg f15;
+  volatile uint64_t _16;
+  Reg f16;
+  volatile uint64_t _17;
+  Reg f17;
+  volatile uint64_t _18;
+  Reg f18;
+  volatile uint64_t _19;
+  Reg f19;
+  volatile uint64_t _20;
+  Reg f20;
+  volatile uint64_t _21;
+  Reg f21;
+  volatile uint64_t _22;
+  Reg f22;
+  volatile uint64_t _23;
+  Reg f23;
+  volatile uint64_t _24;
+  Reg f24;
+  volatile uint64_t _25;
+  Reg f25;
+  volatile uint64_t _26;
+  Reg f26;
+  volatile uint64_t _27;
+  Reg f27;
+  volatile uint64_t _28;
+  Reg f28;
+  volatile uint64_t _29;
+  Reg f29;
+  volatile uint64_t _30;
+  Reg f30;
+  volatile uint64_t _31;
+  Reg f31;
+
+} __attribute__((packed));
+
+static_assert(512 == sizeof(FPR), "Invalid structure packing of `FPR`.");
+
+struct alignas(8) FlagRegisters final {
+  volatile uint64_t _0;
+  Reg ISAModeSwitch;
+} __attribute__((packed));
+
+struct alignas(8) COP0Registers final {
+  volatile uint64_t _0;
+  Reg Index;
+  volatile uint64_t _1;
+  Reg Random;
+  volatile uint64_t _2;
+  Reg EntryLo0;
+  volatile uint64_t _3;
+  Reg EntryLo1;
+  volatile uint64_t _4;
+  Reg Context;
+  volatile uint64_t _5;
+  Reg PageMask;
+  volatile uint64_t _6;
+  Reg Wired;
+  volatile uint64_t _7;
+  Reg HWREna;
+  volatile uint64_t _8;
+  Reg BadVAddr;
+  volatile uint64_t _9;
+  Reg Count;
+  volatile uint64_t _10;
+  Reg EntryHi;
+  volatile uint64_t _11;
+  Reg Compare;
+  volatile uint64_t _12;
+  Reg Status;
+  volatile uint64_t _13;
+  Reg Cause;
+  volatile uint64_t _14;
+  Reg EPC;
+  volatile uint64_t _15;
+  Reg PRId;
+  volatile uint64_t _16;
+  Reg Config;
+  volatile uint64_t _17;
+  Reg LLAddr;
+  volatile uint64_t _18;
+  Reg WatchLo;
+  volatile uint64_t _19;
+  Reg WatchHi;
+  volatile uint64_t _20;
+  Reg XContext;
+  volatile uint64_t _21;
+  Reg cop0_reg21;
+  volatile uint64_t _22;
+  Reg cop0_reg22;
+  volatile uint64_t _23;
+  Reg Debug;
+  volatile uint64_t _24;
+  Reg DEPC;
+  volatile uint64_t _25;
+  Reg PerfCnt;
+  volatile uint64_t _26;
+  Reg ErrCtl;
+  volatile uint64_t _27;
+  Reg CacheErr;
+  volatile uint64_t _28;
+  Reg TagLo;
+  volatile uint64_t _29;
+  Reg TagHi;
+  volatile uint64_t _30;
+  Reg ErrorEPC;
+  volatile uint64_t _31;
+  Reg DESAVE;
+} __attribute__((packed));
+
+struct alignas(8) MIPSState : public ArchState {
+  GPR gpr;  // 528 bytes.
+
+  uint64_t _0;
+
+  FPR fpr;
+
+  uint64_t _1;
+
+  FlagRegisters flags;
+
+  uint64_t _2;
+
+  COP0Registers cop0;
+
+  uint64_t _3;
+} __attribute__((packed));
+
+struct State : public MIPSState {};
+
+#pragma clang diagnostic pop

--- a/include/remill/Arch/Name.h
+++ b/include/remill/Arch/Name.h
@@ -121,6 +121,7 @@ enum ArchName : uint32_t {
   kArchThumb2LittleEndian,
 
   kArchPPC,
+  kArchMIPS,
 };
 
 ArchName GetArchName(const llvm::Triple &triple);

--- a/include/remill/Arch/Runtime/HyperCall.h
+++ b/include/remill/Arch/Runtime/HyperCall.h
@@ -96,6 +96,9 @@ class SyncHyperCall {
 
     kPPCEmulateInstruction,
     kPPCSysCall,
+
+    kMIPSEmulateInstruction,
+    kMIPSSysCall,
   };
 } __attribute__((packed));
 

--- a/include/remill/Arch/Runtime/Intrinsics.h
+++ b/include/remill/Arch/Runtime/Intrinsics.h
@@ -425,4 +425,8 @@ __remill_ppc_emulate_instruction(Memory *);
 
 [[gnu::used, gnu::const]] extern Memory *__remill_ppc_syscall(Memory *);
 
+[[gnu::used, gnu::const]] extern Memory *__remill_mips_emulate_instruction(Memory *);
+
+[[gnu::used, gnu::const]] extern Memory *__remill_mips_syscall(Memory *);
+
 }  // extern C

--- a/lib/Arch/Arch.cpp
+++ b/lib/Arch/Arch.cpp
@@ -58,6 +58,7 @@ static unsigned AddressSize(ArchName arch_name) {
     case kArchThumb2LittleEndian:
     case kArchSparc32:
     case kArchSparc32_SLEIGH:
+    case kArchMIPS: return 32; // Actually MIPS64 but on 32bit Address bus for vr4300
     case kArchPPC: return 32;
     case kArchAMD64:
     case kArchAMD64_AVX:
@@ -117,6 +118,7 @@ ArchLocker Arch::Lock(ArchName arch_name_) {
     case ArchName::kArchX86_SLEIGH:
     case ArchName::kArchSparc32_SLEIGH:
     case ArchName::kArchPPC: return &gSleighArchLock;
+    case ArchName::kArchMIPS: return &gSleighArchLock;
     default: return ArchLocker();
   }
 }
@@ -247,6 +249,10 @@ auto Arch::GetArchByName(llvm::LLVMContext *context_, OSName os_name_,
       return GetSleighPPC(context_, os_name_, arch_name_);
     }
 
+    case kArchMIPS: {
+      DLOG(INFO) << "Using architecture: MIPS";
+      return GetSleighMIPS(context_, os_name_, arch_name_);
+    }
     default: {
       return nullptr;
     }
@@ -426,6 +432,10 @@ bool Arch::IsSPARC64(void) const {
 
 bool Arch::IsPPC(void) const {
   return remill::kArchPPC == arch_name;
+}
+
+bool Arch::IsMIPS(void) const {
+  return remill::kArchMIPS == arch_name;
 }
 
 bool Arch::IsWindows(void) const {

--- a/lib/Arch/CMakeLists.txt
+++ b/lib/Arch/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library(remill_arch STATIC
 add_subdirectory(AArch32)
 add_subdirectory(AArch64)
 add_subdirectory(PPC)
+add_subdirectory(MIPS)
 add_subdirectory(SPARC32)
 add_subdirectory(SPARC64)
 add_subdirectory(Sleigh)

--- a/lib/Arch/Instruction.cpp
+++ b/lib/Arch/Instruction.cpp
@@ -673,6 +673,7 @@ std::string Instruction::Serialize(void) const {
       case kArchSparc32: ss << "SPARC32"; break;
       case kArchSparc64: ss << "SPARC64"; break;
       case kArchPPC: ss << "PowerPC"; break;
+      case kArchMIPS: ss << "MIPS"; break;
     }
   };
 

--- a/lib/Arch/MIPS/CMakeLists.txt
+++ b/lib/Arch/MIPS/CMakeLists.txt
@@ -1,0 +1,1 @@
+add_subdirectory(Runtime)

--- a/lib/Arch/MIPS/Runtime/CMakeLists.txt
+++ b/lib/Arch/MIPS/Runtime/CMakeLists.txt
@@ -1,0 +1,44 @@
+# Copyright (c) 2022-present Trail of Bits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+cmake_minimum_required(VERSION 3.6)
+project(mips_runtime)
+
+set(MIPSRUNTIME_SOURCEFILES
+  Instructions.cpp
+
+  "${REMILL_LIB_DIR}/Arch/Runtime/Intrinsics.cpp"
+)
+
+set_source_files_properties(BasicBlock.cpp PROPERTIES COMPILE_FLAGS "-O3 -g0")
+
+# Visual C++ requires C++14
+if(WIN32)
+  set(required_cpp_standard "c++14")
+else()
+  set(required_cpp_standard "c++17")
+endif()
+
+add_runtime(mips
+  SOURCES ${MIPSRUNTIME_SOURCEFILES}
+  ADDRESS_SIZE 32
+  DEFINITIONS "LITTLE_ENDIAN=${little_endian}" "REMILL_DISABLE_INT128=1"
+  BCFLAGS "-std=${required_cpp_standard}"
+  INCLUDEDIRECTORIES "${REMILL_INCLUDE_DIR}" "${REMILL_SOURCE_DIR}"
+  INSTALLDESTINATION "${REMILL_INSTALL_SEMANTICS_DIR}"
+  ARCH mips64
+
+  DEPENDENCIES
+  "${REMILL_INCLUDE_DIR}/remill/Arch/MIPS/Runtime/State.h"
+)

--- a/lib/Arch/MIPS/Runtime/Instructions.cpp
+++ b/lib/Arch/MIPS/Runtime/Instructions.cpp
@@ -1,0 +1,43 @@
+/*
+ * Copyright (c) 2022-present Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "remill/Arch/MIPS/Runtime/State.h"
+#include "remill/Arch/Runtime/Float.h"
+#include "remill/Arch/Runtime/Intrinsics.h"
+#include "remill/Arch/Runtime/Operators.h"
+
+// A definition is required to ensure that LLVM doesn't optimize the `State` type out of the bytecode
+// See https://github.com/lifting-bits/remill/pull/631#issuecomment-1279989004f
+State __remill_state;
+
+#define HYPER_CALL state.hyper_call
+
+namespace {
+
+DEF_SEM(HandleUnsupported) {
+  return __remill_sync_hyper_call(state, memory,
+                                  SyncHyperCall::kMIPSEmulateInstruction);
+}
+
+DEF_SEM(HandleInvalidInstruction) {
+  HYPER_CALL = AsyncHyperCall::kInvalidInstruction;
+  return memory;
+}
+
+}  // namespace
+
+DEF_ISEL(UNSUPPORTED_INSTRUCTION) = HandleUnsupported;
+DEF_ISEL(INVALID_INSTRUCTION) = HandleInvalidInstruction;

--- a/lib/Arch/Name.cpp
+++ b/lib/Arch/Name.cpp
@@ -30,6 +30,7 @@ ArchName GetArchName(const llvm::Triple &triple) {
     case llvm::Triple::sparc: return kArchSparc32;
     case llvm::Triple::sparcv9: return kArchSparc64;
     case llvm::Triple::ppc: return kArchPPC;
+    case llvm::Triple::mips64: return kArchMIPS;
     default: return kArchInvalid;
   }
 }
@@ -75,10 +76,10 @@ ArchName GetArchName(std::string_view arch_name) {
 
   } else if (arch_name == "sparc32_sleigh") {
     return kArchSparc32_SLEIGH;
-
+  } else if (arch_name == "mips") {
+    return kArchMIPS;
   } else if (arch_name == "ppc") {
     return kArchPPC;
-
   } else if (arch_name == "aarch64_sleigh") {
     return kArchAArch64LittleEndian_SLEIGH;
   } else {
@@ -106,6 +107,7 @@ static const std::string_view kArchNames[] = {
     [kArchSparc32_SLEIGH] = "sparc32_sleigh",
     [kArchThumb2LittleEndian] = "thumb2",
     [kArchPPC] = "ppc",
+    [kArchMIPS] = "mips",
 };
 
 }  // namespace

--- a/lib/Arch/Runtime/HyperCall.cpp
+++ b/lib/Arch/Runtime/HyperCall.cpp
@@ -26,6 +26,9 @@
 #elif defined(__aarch64__)
 #  include "remill/Arch/AArch64/Runtime/State.h"
 #  define REMILL_HYPERCALL_AARCH64 1
+#elif defined(__mips__)
+#  include "remill/Arch/MIPS/Runtime/State.h"
+#  define REMILL_HYPERCALL_MIPS 1
 #elif defined(__sparc__)
 #  if ADDRESS_SIZE_BITS == 32
 #    include "remill/Arch/SPARC32/Runtime/State.h"
@@ -379,9 +382,15 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
       break;
 
 #  endif
+#elif defined(REMILL_HYPERCALL_MIPS)
+    case SyncHyperCall::kMIPSEmulateInstruction:
+      mem = __remill_mips_emulate_instruction(mem);
+      break;
 
+  case SyncHyperCall::kMIPSSysCall:
+      mem = __remill_mips_syscall(mem);
+      break;
 #elif defined(REMILL_HYPERCALL_PPC)
-
     case SyncHyperCall::kPPCEmulateInstruction:
       mem = __remill_ppc_emulate_instruction(mem);
       break;

--- a/lib/Arch/Sleigh/CMakeLists.txt
+++ b/lib/Arch/Sleigh/CMakeLists.txt
@@ -39,14 +39,17 @@ add_library(remill_arch_sleigh STATIC
   "${REMILL_INCLUDE_DIR}/remill/Arch/SPARC32/SPARC32Base.h"
 
   "${REMILL_INCLUDE_DIR}/remill/Arch/PPC/Runtime/State.h"
+  "${REMILL_INCLUDE_DIR}/remill/Arch/MIPS/Runtime/State.h"
 
   Arch.h
   Thumb.h
   PPC.h
+  MIPS.h
   Arch.cpp
   X86Arch.cpp
   Thumb2Arch.cpp
   PPCArch.cpp
+  MIPSArch.cpp
   ControlFlowStructuring.cpp
   ControlFlowStructuring.h
 

--- a/lib/Arch/Sleigh/MIPS.h
+++ b/lib/Arch/Sleigh/MIPS.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022-present Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#pragma once
+
+#include <remill/Arch/Context.h>
+#include <remill/Arch/Name.h>
+#include <remill/BC/ABI.h>
+#include <remill/BC/Util.h>
+#include <remill/BC/Version.h>
+#include <remill/OS/OS.h>
+
+#include "Arch.h"
+
+namespace remill::sleighmips {
+
+class SleighMIPSDecoder final : public remill::sleigh::SleighDecoder {
+ public:
+  SleighMIPSDecoder(const remill::Arch &);
+
+  llvm::Value *LiftPcFromCurrPc(llvm::IRBuilder<> &, llvm::Value *, size_t,
+                                const DecodingContext &) const override;
+
+  void InitializeSleighContext(uint64_t addr,
+                               remill::sleigh::SingleInstructionSleighContext &,
+                               const ContextValues &) const override;
+};
+
+}  // namespace remill::sleighmips

--- a/lib/Arch/Sleigh/MIPSArch.cpp
+++ b/lib/Arch/Sleigh/MIPSArch.cpp
@@ -1,0 +1,379 @@
+/*
+ * Copyright (c) 2022-present Trail of Bits, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "Arch.h"
+#include "MIPS.h"
+
+#define INCLUDED_FROM_REMILL
+#include <remill/Arch/MIPS/Runtime/State.h>
+
+namespace remill {
+
+namespace sleighmips {
+SleighMIPSDecoder::SleighMIPSDecoder(const remill::Arch &arch)
+    : SleighDecoder(
+          arch, "mips64be.sla", "mips64.pspec",
+                    sleigh::ContextRegMappings(
+                        {}, {}), {}) {}
+
+llvm::Value *SleighMIPSDecoder::LiftPcFromCurrPc(llvm::IRBuilder<> &bldr,
+                                                llvm::Value *curr_pc,
+                                                size_t curr_insn_size,
+                                                const DecodingContext &) const {
+  return bldr.CreateAdd(curr_pc, llvm::ConstantInt::get(curr_pc->getType(), 4));
+}
+
+void SleighMIPSDecoder::InitializeSleighContext(
+    uint64_t addr, remill::sleigh::SingleInstructionSleighContext &ctxt,
+    const ContextValues &values) const {
+    //sleigh::SetContextRegisterValueInSleigh(
+    //  addr, std::string("ZERO").c_str(), "zero", 0, ctxt, values);
+}
+
+class SleighMIPSArch : public ArchBase {
+ public:
+  SleighMIPSArch(llvm::LLVMContext *context_, OSName os_name_,
+                ArchName arch_name_)
+      : ArchBase(context_, os_name_, arch_name_),
+        decoder(*this) {}
+  virtual ~SleighMIPSArch() = default;
+
+  DecodingContext CreateInitialContext(void) const override {
+    return DecodingContext();
+  }
+
+  std::string_view StackPointerRegisterName(void) const override {
+    return "SP";
+  }
+
+  std::string_view ProgramCounterRegisterName(void) const override {
+    return "PC";
+  }
+
+  OperandLifter::OpLifterPtr
+  DefaultLifter(const remill::IntrinsicTable &intrinsics) const override {
+    return decoder.GetOpLifter();
+  }
+
+  bool DecodeInstruction(uint64_t address, std::string_view instr_bytes,
+                         Instruction &inst,
+                         DecodingContext context) const override {
+    inst.pc = address;
+    inst.next_pc = address + instr_bytes.size();  // Default fall-through.
+    inst.branch_taken_pc = 0;
+    inst.branch_not_taken_pc = 0;
+    inst.has_branch_taken_delay_slot = false;
+    inst.has_branch_not_taken_delay_slot = false;
+    inst.arch_name = arch_name;
+    inst.sub_arch_name = arch_name;
+    inst.branch_taken_arch_name = arch_name;
+    inst.arch = this;
+    inst.category = Instruction::kCategoryInvalid;
+    inst.operands.clear();
+    inst.flows = Instruction::InvalidInsn();
+
+    context.UpdateContextReg(std::string("ZERO"), 0); // What to do here?
+
+    return this->decoder.DecodeInstruction(address, instr_bytes, inst, context);
+  }
+
+  uint64_t MinInstructionAlign(const DecodingContext &) const override {
+    return 4;
+  }
+
+  uint64_t MinInstructionSize(const DecodingContext &) const override {
+    return 4;
+  }
+
+  uint64_t MaxInstructionSize(const DecodingContext &,
+                              bool permit_fuse_idioms) const {
+    return permit_fuse_idioms ? 8 : 4;  // To handle delayslots, apparently
+  }
+
+  // Returns `true` if we should lift the semantics of `next_inst` as a delay
+  // slot of `inst`. The `branch_taken_path` tells us whether we are in the
+  // context of the taken path of a branch or the not-taken path of a branch.
+  bool NextInstructionIsDelayed(const Instruction &inst,
+                                            const Instruction &next_inst,
+                                            bool branch_taken_path) const {
+    if (inst.delayed_pc != next_inst.pc) {
+      return false;
+    }
+
+    if (branch_taken_path) {
+      return inst.has_branch_taken_delay_slot;
+    } else {
+      return inst.has_branch_not_taken_delay_slot;
+    }
+  }
+
+  // Returns `true` if a given instruction might have a delay slot.
+  bool MayHaveDelaySlot(const Instruction &inst) const {
+    return inst.has_branch_taken_delay_slot ||
+          inst.has_branch_not_taken_delay_slot;
+  }
+
+  // Returns `true` if memory access are little endian byte ordered.
+  bool MemoryAccessIsLittleEndian(void) const {
+    return false;
+  }
+
+  llvm::CallingConv::ID DefaultCallingConv(void) const override {
+    return llvm::CallingConv::C;
+  }
+
+  llvm::Triple Triple(void) const override {
+    auto triple = BasicTriple();
+    triple.setArch(llvm::Triple::mips64);
+    return triple;
+  }
+
+  llvm::DataLayout DataLayout(void) const override {
+    return llvm::DataLayout("E-m:e-p:32:32-i64:64-f128:64-n32-S64");
+  }
+
+  void PopulateRegisterTable(void) const override {
+    CHECK_NOTNULL(context);
+
+    reg_by_offset.resize(sizeof(MIPSState));
+
+    auto u8 = llvm::Type::getInt8Ty(*context);
+    auto u32 = llvm::Type::getInt32Ty(*context);
+    auto u64 = llvm::Type::getInt64Ty(*context);
+
+    auto f32 = llvm::Type::getFloatTy(*context);
+    auto f64 = llvm::Type::getDoubleTy(*context);
+
+#define OFFSET_OF(type, access) \
+  (reinterpret_cast<uintptr_t>(&reinterpret_cast<const volatile char &>( \
+      static_cast<type *>(nullptr)->access)))
+
+#define REG(name, access, type) \
+  AddRegister(#name, type, OFFSET_OF(MIPSState, access), nullptr)
+
+#define SUB_REG(name, access, type, parent_reg_name) \
+  AddRegister(#name, type, OFFSET_OF(MIPSState, access), #parent_reg_name)
+
+    REG(ZERO, gpr.zero.qword, u64);
+    SUB_REG(ZERO_LO, gpr.zero.dword, u32, ZERO);
+    REG(AT, gpr.at.qword, u64);
+    SUB_REG(AT_LO, gpr.at.dword, u32, AT);
+    REG(V0, gpr.v0.qword, u64);
+    SUB_REG(V0_LO, gpr.v0.dword, u32, V0);
+    REG(V1, gpr.v1.qword, u64);
+    SUB_REG(V1_LO, gpr.v1.dword, u32, V1);
+    REG(A0, gpr.a0.qword, u64);
+    SUB_REG(A0_LO, gpr.a0.dword, u32, A0);
+    REG(A1, gpr.a1.qword, u64);
+    SUB_REG(A1_LO, gpr.a1.dword, u32, A1);
+    REG(A2, gpr.a2.qword, u64);
+    SUB_REG(A2_LO, gpr.a2.dword, u32, A2);
+    REG(A3, gpr.a3.qword, u64);
+    SUB_REG(A3_LO, gpr.a3.dword, u32, A3);
+    REG(T0, gpr.t0.qword, u64);
+    SUB_REG(T0_LO, gpr.t0.dword, u32, T0);
+    REG(T1, gpr.t1.qword, u64);
+    SUB_REG(T1_LO, gpr.t1.dword, u32, T1);
+    REG(T2, gpr.t2.qword, u64);
+    SUB_REG(T2_LO, gpr.t2.dword, u32, T2);
+    REG(T3, gpr.t3.qword, u64);
+    SUB_REG(T3_LO, gpr.t3.dword, u32, T3);
+    REG(T4, gpr.t4.qword, u64);
+    SUB_REG(T4_LO, gpr.t4.dword, u32, T4);
+    REG(T5, gpr.t5.qword, u64);
+    SUB_REG(T5_LO, gpr.t5.dword, u32, T5);
+    REG(T6, gpr.t6.qword, u64);
+    SUB_REG(T6_LO, gpr.t6.dword, u32, T6);
+    REG(T7, gpr.t7.qword, u64);
+    SUB_REG(T7_LO, gpr.t7.dword, u32, T7);
+    REG(S0, gpr.s0.qword, u64);
+    SUB_REG(S0_LO, gpr.s0.dword, u32, S0);
+    REG(S1, gpr.s1.qword, u64);
+    SUB_REG(S1_LO, gpr.s1.dword, u32, S1);
+    REG(S2, gpr.s2.qword, u64);
+    SUB_REG(S2_LO, gpr.s2.dword, u32, S2);
+    REG(S3, gpr.s3.qword, u64);
+    SUB_REG(S3_LO, gpr.s3.dword, u32, S3);
+    REG(S4, gpr.s4.qword, u64);
+    SUB_REG(S4_LO, gpr.s4.dword, u32, S4);
+    REG(S5, gpr.s5.qword, u64);
+    SUB_REG(S5_LO, gpr.s5.dword, u32, S5);
+    REG(S6, gpr.s6.qword, u64);
+    SUB_REG(S6_LO, gpr.s6.dword, u32, S6);
+    REG(S7, gpr.s7.qword, u64);
+    SUB_REG(S7_LO, gpr.s7.dword, u32, S7);
+    REG(T8, gpr.t8.qword, u64);
+    SUB_REG(T8_LO, gpr.t8.dword, u32, T8);
+    REG(T9, gpr.t9.qword, u64);
+    SUB_REG(T9_LO, gpr.t9.dword, u32, T9);
+    REG(K0, gpr.k0.qword, u64);
+    SUB_REG(K0_LO, gpr.k0.dword, u32, K0);
+    REG(K1, gpr.k1.qword, u64);
+    SUB_REG(K1_LO, gpr.k1.dword, u32, K1);
+    REG(GP, gpr.gp.qword, u64);
+    SUB_REG(GP_LO, gpr.gp.dword, u32, GP);
+    REG(SP, gpr.sp.qword, u64);
+    SUB_REG(SP_LO, gpr.sp.dword, u32, SP);
+    REG(S8, gpr.s8.qword, u64);
+    SUB_REG(S8_LO, gpr.s8.dword, u32, S8);
+    REG(RA, gpr.ra.qword, u64);
+    SUB_REG(RA_LO, gpr.ra.dword, u32, RA);
+    REG(PC, gpr.pc.qword, u64);
+    SUB_REG(PC_LO, gpr.pc.dword, u32, PC);
+    
+    // Flags
+    REG(ISAMODESWITCH, flags.ISAModeSwitch.qword, u8);
+
+    // FPR
+    REG(F0, fpr.f0.qword, f64);
+    SUB_REG(F0_LO, fpr.f0.dword, f32, F0);
+    REG(F1, fpr.f1.qword, f64);
+    SUB_REG(F1_LO, fpr.f1.dword, f32, F1);
+    REG(F2, fpr.f2.qword, f64);
+    SUB_REG(F2_LO, fpr.f2.dword, f32, F2);
+    REG(F3, fpr.f3.qword, f64);
+    SUB_REG(F3_LO, fpr.f3.dword, f32, F3);
+    REG(F4, fpr.f4.qword, f64);
+    SUB_REG(F4_LO, fpr.f4.dword, f32, F4);
+    REG(F5, fpr.f5.qword, f64);
+    SUB_REG(F5_LO, fpr.f5.dword, f32, F5);
+    REG(F6, fpr.f6.qword, f64);
+    SUB_REG(F6_LO, fpr.f6.dword, f32, F6);
+    REG(F7, fpr.f7.qword, f64);
+    SUB_REG(F7_LO, fpr.f7.dword, f32, F7);
+    REG(F8, fpr.f8.qword, f64);
+    SUB_REG(F8_LO, fpr.f8.dword, f32, F8);
+    REG(F9, fpr.f9.qword, f64);
+    SUB_REG(F9_LO, fpr.f9.dword, f32, F9);
+    REG(F10, fpr.f10.qword, f64);
+    SUB_REG(F10_LO, fpr.f10.dword, f32, F10);
+    REG(F11, fpr.f11.qword, f64);
+    SUB_REG(F11_LO, fpr.f11.dword, f32, F11);
+    REG(F12, fpr.f12.qword, f64);
+    SUB_REG(F12_LO, fpr.f12.dword, f32, F12);
+    REG(F13, fpr.f13.qword, f64);
+    SUB_REG(F13_LO, fpr.f13.dword, f32, F13);
+    REG(F14, fpr.f14.qword, f64);
+    SUB_REG(F14_LO, fpr.f14.dword, f32, F14);
+    REG(F15, fpr.f15.qword, f64);
+    SUB_REG(F15_LO, fpr.f15.dword, f32, F15);
+    REG(F16, fpr.f16.qword, f64);
+    SUB_REG(F16_LO, fpr.f16.dword, f32, F16);
+    REG(F17, fpr.f17.qword, f64);
+    SUB_REG(F17_LO, fpr.f17.dword, f32, F17);
+    REG(F18, fpr.f18.qword, f64);
+    SUB_REG(F18_LO, fpr.f18.dword, f32, F18);
+    REG(F19, fpr.f19.qword, f64);
+    SUB_REG(F19_LO, fpr.f19.dword, f32, F19);
+    REG(F20, fpr.f20.qword, f64);
+    SUB_REG(F20_LO, fpr.f20.dword, f32, F20);
+    REG(F21, fpr.f21.qword, f64);
+    SUB_REG(F21_LO, fpr.f21.dword, f32, F21);
+    REG(F22, fpr.f22.qword, f64);
+    SUB_REG(F22_LO, fpr.f22.dword, f32, F22);
+    REG(F23, fpr.f23.qword, f64);
+    SUB_REG(F23_LO, fpr.f23.dword, f32, F23);
+    REG(F24, fpr.f24.qword, f64);
+    SUB_REG(F24_LO, fpr.f24.dword, f32, F24);
+    REG(F25, fpr.f25.qword, f64);
+    SUB_REG(F25_LO, fpr.f25.dword, f32, F25);
+    REG(F26, fpr.f26.qword, f64);
+    SUB_REG(F26_LO, fpr.f26.dword, f32, F26);
+    REG(F27, fpr.f27.qword, f64);
+    SUB_REG(F27_LO, fpr.f27.dword, f32, F27);
+    REG(F28, fpr.f28.qword, f64);
+    SUB_REG(F28_LO, fpr.f28.dword, f32, F28);
+    REG(F29, fpr.f29.qword, f64);
+    SUB_REG(F29_LO, fpr.f29.dword, f32, F29);
+    REG(F30, fpr.f30.qword, f64);
+    SUB_REG(F30_LO, fpr.f30.dword, f32, F30);
+    REG(F31, fpr.f31.qword, f64);
+    SUB_REG(F31_LO, fpr.f31.dword, f32, F31);
+
+    // COP0
+    REG(INDEX, cop0.Index.qword, u64);
+    REG(RANDOM, cop0.Random.qword, u64);
+    REG(ENTRYLO0, cop0.EntryLo0.qword, u64);
+    REG(ENTRYLO1, cop0.EntryLo1.qword, u64);
+    REG(CONTEXT, cop0.Context.qword, u64);
+    REG(PAGEMASK, cop0.PageMask.qword, u64);
+    REG(WIRED, cop0.Wired.qword, u64);
+    REG(HWRENA, cop0.HWREna.qword, u64);
+    REG(BADVADDR, cop0.BadVAddr.qword, u64);
+    REG(COUNT, cop0.Count.qword, u64);
+    REG(ENTRYHI, cop0.EntryHi.qword, u64);
+    REG(COMPARE, cop0.Compare.qword, u64);
+    REG(STATUS, cop0.Status.qword, u64);
+    REG(CAUSE, cop0.Cause.qword, u64);
+    REG(EPC, cop0.EPC.qword, u64);
+    REG(PRID, cop0.PRId.qword, u64);
+    REG(CONFIG, cop0.Config.qword, u64);
+    REG(LLADDR, cop0.LLAddr.qword, u64);
+    REG(WATCHLO, cop0.WatchLo.qword, u64);
+    REG(WATCHHI, cop0.WatchHi.qword, u64);
+    REG(XCONTEXT, cop0.XContext.qword, u64);
+    REG(COP0_REG21, cop0.cop0_reg21.qword, u64);
+    REG(COP0_REG22, cop0.cop0_reg22.qword, u64);
+    REG(DEBUG, cop0.Debug.qword, u64);
+    REG(DEPC, cop0.DEPC.qword, u64);
+    REG(PERFCNT, cop0.PerfCnt.qword, u64);
+    REG(ERRCTL, cop0.ErrCtl.qword, u64);
+    REG(CACHEERR, cop0.CacheErr.qword, u64);
+    REG(TAGLO, cop0.TagLo.qword, u64);
+    REG(TAGHI, cop0.TagHi.qword, u64);
+    REG(ERRORPC, cop0.ErrorEPC.qword, u64);
+    REG(DESAVE, cop0.DESAVE.qword, u64);
+  }
+
+  void
+  FinishLiftedFunctionInitialization(llvm::Module *module,
+                                     llvm::Function *bb_func) const override {
+    auto &context = module->getContext();
+    const auto addr = llvm::Type::getInt64Ty(context);
+
+    auto &entry_block = bb_func->getEntryBlock();
+    llvm::IRBuilder<> ir(&entry_block);
+
+    const auto pc_arg = NthArgument(bb_func, kPCArgNum);
+    const auto state_ptr_arg = NthArgument(bb_func, kStatePointerArgNum);
+
+    auto mk_alloca = [&](auto &from) {
+      return ir.CreateAlloca(addr, nullptr, from.data());
+    };
+    ir.CreateStore(pc_arg, mk_alloca(kNextPCVariableName));
+    ir.CreateStore(pc_arg, mk_alloca(kIgnoreNextPCVariableName));
+
+    /*auto u8 = llvm::Type::getInt8Ty(context);
+    auto zero_c = ir.CreateAlloca(u8, nullptr, "ZERO");
+    ir.CreateStore(llvm::Constant::getNullValue(u8), zero_c);*/
+    
+    std::ignore = RegisterByName(kPCVariableName)->AddressOf(state_ptr_arg, ir);
+  }
+
+ private:
+  SleighMIPSDecoder decoder;
+};
+
+}  // namespace sleighmips
+
+Arch::ArchPtr Arch::GetSleighMIPS(llvm::LLVMContext *context_,
+                                 remill::OSName os_name_,
+                                 remill::ArchName arch_name_) {
+  return std::make_unique<sleighmips::SleighMIPSArch>(context_, os_name_,
+                                                    arch_name_);
+}
+
+}  // namespace remill


### PR DESCRIPTION
As discussed on Slack, here is a quick PR with my current WIP state for MIPS Support (specifically N64 / vr4300 and PS1 later on).
We will need to figure how we split mips32/64 big/little endian variants as well as mips64 with 32bit addr bus in both flavours in a sane matter. I just treat the mips64_32_be target basically as a generic mips target in remill right now, this needs to be reworked.

Some more register stuff needs to be reworked too, but in my testing it works quite nice already.
Hope i didnt have a oversight when i squashed some ppc related changes out..

I run low on time now but can add more infos regarding this PR later on or as requested.

I also noticed MaxInstructionSize needs to permit the idom, I think it merges delayslot together? All mips opcodes are expected to be u32, would be nice to get that confirmed as reason.

Requesting Review from @2over12