### PR TITLE
Fix big endian type conversions for registers

### DIFF
--- a/lib/BC/SleighLifter.cpp
+++ b/lib/BC/SleighLifter.cpp
@@ -141,7 +141,7 @@ class SleighLifter::PcodeToLLVMEmitIntoBlock {
                                                        llvm::Type *ty) {
       auto mayberes = this->LiftAsInParamNoConvert(bldr, vnode_type);
       if (!mayberes) {
-        return mayberes;
+        return std::nullopt;
       }
 
       auto res = *mayberes;


### PR DESCRIPTION
In the sleigh lifter parameters are sometimes lifted as word type, regardless of their varnode size in order to produce an address (ie. at CPUI_LOAD/STORE). Previously this was transparently handled by the Register param loading. This doesnt really work on big endian systems since we will load the high bits. We now insert explicit integer<->integer conversion