### PR TITLE
Add rpm-build to apt readme dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,8 @@ sudo apt-get install \
      ccache \
      libc6-dev:i386 \
      'libstdc++-*-dev:i386' \
-     g++-multilib
+     g++-multilib \
+     rpm
 ```
 
 Next, clone the repository. This will clone the code into the `remill` directory.


### PR DESCRIPTION
I got an error that `rpm-build` wasn't installed despite following the readme. I had to `apt install rpm` to fix this.