### PR TITLE
Fix breakpoint instruction on AArch64.

### DIFF
--- a/lib/Arch/Runtime/HyperCall.cpp
+++ b/lib/Arch/Runtime/HyperCall.cpp
@@ -282,7 +282,18 @@ Memory *__remill_sync_hyper_call(State &state, Memory *mem,
       mem = __remill_aarch64_emulate_instruction(mem);
       break;
 
-    case SyncHyperCall::kAArch64Breakpoint: asm volatile("bkpt" :); break;
+    case SyncHyperCall::kAArch64Breakpoint:
+#  ifdef __has_builtin
+#    if __has_builtin(__builtin_debugtrap)
+      __builtin_debugtrap();
+#      define REMILL_USED_DEBUG_TRAP
+#    endif
+#  endif
+#  ifndef REMILL_USED_DEBUG_TRAP
+      asm volatile("brk #0");
+#  endif
+#  undef REMILL_USED_DEBUG_TRAP
+      break;
 
 #elif REMILL_HYPERCALL_SPARC32 || REMILL_HYPERCALL_SPARC64
 


### PR DESCRIPTION
## Description

Hello! `Arm® Architecture Reference Manual for A-profile architecture` explains about the breakpoint instructions as follows.
> The breakpoint instruction in the A64 instruction set is BRK #<immediate>. It is unconditional.
The breakpoint instruction in the A32 and T32 instruction sets is BKPT #<immediate>.

When I built Remill on an arm64 host, the following error occurred.

```bash
<inline asm>:1:2: error: unrecognized instruction mnemonic
        bkpt
        ^
error: cannot compile inline asm
```
Then, this PR changes the arm64 breakpoint instruction from `bkpt` to `brk #0`.