### PR TITLE
Fix missing includes in Arch & OS headers.

### DIFF
--- a/include/remill/Arch/Name.h
+++ b/include/remill/Arch/Name.h
@@ -90,6 +90,7 @@
 #  endif
 #endif
 
+#include <cstdint>
 #include <string_view>
 
 namespace llvm {
@@ -97,7 +98,7 @@ class Triple;
 }  // namespace llvm
 namespace remill {
 
-enum ArchName : uint32_t {
+enum ArchName : std::uint32_t {
   kArchInvalid,
 
   kArchX86,

--- a/include/remill/OS/OS.h
+++ b/include/remill/OS/OS.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 
 #ifndef REMILL_OS
@@ -58,7 +59,7 @@ class Triple;
 }  // namespace llvm
 namespace remill {
 
-enum OSName : uint32_t {
+enum OSName : std::uint32_t {
   kOSInvalid,
   kOSmacOS,
   kOSLinux,


### PR DESCRIPTION
When building under Linux (I run Manjaro, unsure if the distro matters), an error is raised during the compilation process in `include/remill/Arch/Name.h` and `include/remill/OS/OS.h`. This is caused by `uint32_t` not being defined in the global scope. This pull request resolves the problem.