### PR TITLE
Remove deprecated LINK_PUBLIC/PRIVATE specifier

### DIFF
--- a/lib/Arch/AArch64/CMakeLists.txt
+++ b/lib/Arch/AArch64/CMakeLists.txt
@@ -33,7 +33,7 @@ add_library(remill_arch_aarch64 STATIC
 
 add_subdirectory(Runtime)
 
-target_link_libraries(remill_arch_aarch64 LINK_PUBLIC
+target_link_libraries(remill_arch_aarch64 PUBLIC
   remill_settings
 )
 

--- a/lib/Arch/CMakeLists.txt
+++ b/lib/Arch/CMakeLists.txt
@@ -34,14 +34,12 @@ add_subdirectory(SPARC64)
 add_subdirectory(Sleigh)
 add_subdirectory(X86)
 
-target_link_libraries(remill_arch LINK_PUBLIC
+target_link_libraries(remill_arch PUBLIC
   remill_arch_aarch64
   remill_arch_sleigh
   remill_arch_sparc32
   remill_arch_sparc64
   remill_arch_x86
-  LINK_PRIVATE
-  remill_settings
 )
 
 if(REMILL_ENABLE_INSTALL_TARGET)

--- a/lib/Arch/SPARC32/CMakeLists.txt
+++ b/lib/Arch/SPARC32/CMakeLists.txt
@@ -33,7 +33,7 @@ if(${REMILL_BUILD_SPARC32_RUNTIME})
   add_subdirectory(Runtime)
 endif()
 
-target_link_libraries(remill_arch_sparc32 LINK_PUBLIC
+target_link_libraries(remill_arch_sparc32 PUBLIC
   remill_settings
 )
 

--- a/lib/Arch/SPARC64/CMakeLists.txt
+++ b/lib/Arch/SPARC64/CMakeLists.txt
@@ -31,7 +31,7 @@ add_library(remill_arch_sparc64 STATIC
   Extract.cpp
 )
 
-target_link_libraries(remill_arch_sparc64 LINK_PUBLIC
+target_link_libraries(remill_arch_sparc64 PUBLIC
   remill_settings
 )
 

--- a/lib/Arch/Sleigh/CMakeLists.txt
+++ b/lib/Arch/Sleigh/CMakeLists.txt
@@ -65,7 +65,7 @@ add_library(remill_arch_sleigh STATIC
 
 add_dependencies(remill_arch_sleigh sleigh_custom_specs)
 
-target_link_libraries(remill_arch_sleigh LINK_PUBLIC
+target_link_libraries(remill_arch_sleigh PUBLIC
   remill_settings
 )
 

--- a/lib/Arch/X86/CMakeLists.txt
+++ b/lib/Arch/X86/CMakeLists.txt
@@ -32,7 +32,7 @@ add_library(remill_arch_x86 STATIC
 
 add_subdirectory(Runtime)
 
-target_link_libraries(remill_arch_x86 LINK_PUBLIC
+target_link_libraries(remill_arch_x86 PUBLIC
   remill_settings
 )
 

--- a/lib/BC/CMakeLists.txt
+++ b/lib/BC/CMakeLists.txt
@@ -37,7 +37,7 @@ add_library(remill_bc STATIC
 
 target_include_directories(remill_bc AFTER PRIVATE "${REMILL_SOURCE_DIR}")
 
-target_link_libraries(remill_bc LINK_PRIVATE
+target_link_libraries(remill_bc PUBLIC
   remill_settings
 )
 

--- a/lib/OS/CMakeLists.txt
+++ b/lib/OS/CMakeLists.txt
@@ -21,7 +21,7 @@ add_library(remill_os STATIC
   OS.cpp
 )
 
-target_link_libraries(remill_os LINK_PRIVATE
+target_link_libraries(remill_os PUBLIC
   remill_settings
 )
 

--- a/lib/Version/CMakeLists.txt
+++ b/lib/Version/CMakeLists.txt
@@ -17,7 +17,7 @@ add_library(remill_version STATIC
   ${POST_CONFIGURE_FILE}
   ${Version_PUBLIC_H}
   )
-target_link_libraries(remill_version LINK_PRIVATE remill_settings)
+target_link_libraries(remill_version PUBLIC remill_settings)
 add_dependencies(remill_version check_git_${PROJECT_NAME})
 
 if(REMILL_ENABLE_INSTALL_TARGET)


### PR DESCRIPTION
https://cmake.org/cmake/help/latest/command/target_link_libraries.html#libraries-for-a-target-and-or-its-dependents-legacy

Looks like with CMake 4 this is no longer populating `INTERFACE_LINK_LIBRARIES`, meaning you need to link to LLVM and remill both instead of just remill to use it. Since LLVM is used in remill's public headers, the `remill_settings` should be linked `PUBLIC` everywhere.