### PR TITLE
Add docker workflow for LLVM 19 and 21

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,5 +1,7 @@
 build
 remill-build
+dependencies/build
+dependencies/install
 Dockerfile*
 .travis.yml
 .github*

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -1,0 +1,79 @@
+name: Build and Publish Docker Images
+
+on:
+  push:
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  REGISTRY: ghcr.io
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    strategy:
+      fail-fast: false
+      matrix:
+        llvm: ["19", "21"]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GitHub Container Registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          # Package name: remill/llvm19-ubuntu22.04
+          images: ${{ env.REGISTRY }}/lifting-bits/remill/llvm${{ matrix.llvm }}-ubuntu22.04
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=sha
+            type=ref,event=tag
+            type=ref,event=pr
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: ./Dockerfile.llvm
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            LLVM_VERSION=${{ matrix.llvm }}
+            UBUNTU_VERSION=22.04
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Test Docker image (PR only)
+        if: github.event_name == 'pull_request'
+        run: |
+          docker build \
+            --build-arg LLVM_VERSION=${{ matrix.llvm }} \
+            --build-arg UBUNTU_VERSION=22.04 \
+            -f Dockerfile.llvm \
+            -t test-image .
+          docker run --rm test-image --version
+          docker run --rm test-image --arch amd64 --ir_out /dev/stdout --bytes c704ba01000000

--- a/Dockerfile.llvm
+++ b/Dockerfile.llvm
@@ -1,0 +1,111 @@
+# Dockerfile for building remill with specific LLVM versions from apt.llvm.org
+# This approach supports newer LLVM versions (19, 22, etc.)
+
+ARG LLVM_VERSION=22
+ARG UBUNTU_VERSION=22.04
+
+FROM ubuntu:${UBUNTU_VERSION} AS builder
+
+ARG LLVM_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    lsb-release \
+    wget \
+    software-properties-common \
+    gnupg \
+    cmake \
+    ninja-build \
+    python-is-python3 \
+    python3-pip \
+    python3-setuptools \
+    python3-venv \
+    git \
+    ca-certificates \
+    && rm -rf /var/lib/apt/lists/*
+
+# Install LLVM from apt.llvm.org
+RUN wget https://apt.llvm.org/llvm.sh && \
+    chmod +x llvm.sh && \
+    ./llvm.sh ${LLVM_VERSION} && \
+    apt-get install -y --no-install-recommends llvm-${LLVM_VERSION}-dev && \
+    rm -rf /var/lib/apt/lists/* llvm.sh
+
+# Set environment variables for build
+ENV LLVM_VERSION=${LLVM_VERSION}
+ENV CC=clang-${LLVM_VERSION}
+ENV CXX=clang++-${LLVM_VERSION}
+
+WORKDIR /remill
+
+# Copy source code
+COPY . .
+
+# Configure git (needed for version detection)
+RUN git config --global user.email "docker@remill.local" && \
+    git config --global user.name "Docker Build" && \
+    git config --global --add safe.directory /remill
+
+# Get LLVM prefix
+RUN echo "LLVM_PREFIX=$(llvm-config-${LLVM_VERSION} --prefix)" > /tmp/llvm_env
+
+# Build dependencies (XED, etc.)
+RUN . /tmp/llvm_env && \
+    cmake -G Ninja -S dependencies -B dependencies/build \
+        -DUSE_EXTERNAL_LLVM=ON \
+        "-DCMAKE_PREFIX_PATH=${LLVM_PREFIX}" && \
+    cmake --build dependencies/build
+
+# Setup Python venv for tests
+RUN python3 -m venv /opt/venv && \
+    /opt/venv/bin/pip install --no-cache-dir scripts/diff_tester_export_insns
+
+# Build remill
+RUN . /tmp/llvm_env && \
+    . /opt/venv/bin/activate && \
+    cmake -G Ninja -B build \
+        "-DCMAKE_PREFIX_PATH=${LLVM_PREFIX};/remill/dependencies/install" \
+        "-DCMAKE_INSTALL_PREFIX=/opt/remill" \
+        -DCMAKE_BUILD_TYPE=Release && \
+    cmake --build build
+
+# Run tests
+RUN cmake --build build --target test_dependencies && \
+    env CTEST_OUTPUT_ON_FAILURE=1 cmake --build build --target test
+
+# Install
+RUN cmake --install build
+
+# Runtime image
+FROM ubuntu:${UBUNTU_VERSION} AS runtime
+
+ARG LLVM_VERSION
+ARG DEBIAN_FRONTEND=noninteractive
+
+# Install runtime dependencies
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    wget \
+    gnupg \
+    lsb-release \
+    software-properties-common \
+    ca-certificates \
+    && wget https://apt.llvm.org/llvm.sh \
+    && chmod +x llvm.sh \
+    && ./llvm.sh ${LLVM_VERSION} \
+    && apt-get install -y --no-install-recommends llvm-${LLVM_VERSION} \
+    && rm -rf /var/lib/apt/lists/* llvm.sh
+
+# Copy remill installation
+COPY --from=builder /opt/remill /opt/remill
+
+# Set environment
+ENV LLVM_VERSION=${LLVM_VERSION}
+ENV PATH="/opt/remill/bin:${PATH}"
+ENV LD_LIBRARY_PATH="/usr/lib/llvm-${LLVM_VERSION}/lib:${LD_LIBRARY_PATH}"
+
+# Create entrypoint script
+RUN echo '#!/bin/sh\nexec remill-lift-'${LLVM_VERSION}' "$@"' > /usr/local/bin/entrypoint.sh && \
+    chmod +x /usr/local/bin/entrypoint.sh
+
+ENTRYPOINT ["/usr/local/bin/entrypoint.sh"]


### PR DESCRIPTION
- New Dockerfile.llvm that uses apt.llvm.org for LLVM installation
- Supports LLVM 19 and 22 (mainline)
- LLVM 22 tagged as 'latest'
- Uses same build approach as CI (external LLVM)
- Runs tests during build on x86_64
- Publishes to ghcr.io on push to master