### PR TITLE
Minor integration fixes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -300,8 +300,10 @@ InstallExternalTarget("ext_llvmlink" "${LLVMLINK_PATH}" "BIN" "${INSTALLED_LLVML
 #
 add_custom_target(semantics)
 
-# shared JIT tools
-add_subdirectory(test_runner_lib)
+# shared JIT test support
+if(REMILL_ENABLE_TESTING)
+  add_subdirectory(test_runner_lib)
+endif()
 
 # tools
 add_subdirectory(bin)

--- a/dependencies/xed.cmake
+++ b/dependencies/xed.cmake
@@ -116,4 +116,4 @@ ExternalProject_Add(xed
 )
 
 # TODO: generate XEDVersion.cmake as well file
-configure_file("${CMAKE_CURRENT_SOURCE_DIR}/XEDConfig.cmake.in" "${CMAKE_INSTALL_PREFIX}/lib/cmake/XED/XEDConfig.cmake" @ONLY)
+configure_file("${CMAKE_CURRENT_LIST_DIR}/XEDConfig.cmake.in" "${CMAKE_INSTALL_PREFIX}/lib/cmake/XED/XEDConfig.cmake" @ONLY)

--- a/include/remill/Arch/Runtime/Types.h
+++ b/include/remill/Arch/Runtime/Types.h
@@ -689,51 +689,51 @@ struct IntegerType<size_t> : public SizeTEquivalent<sizeof(size_t)>::T {};
 
 #if !COMPILING_WITH_GCC
 
-inline uint8_t operator"" _u8(unsigned long long value) {
+inline uint8_t operator""_u8(unsigned long long value) {
   return static_cast<uint8_t>(value);
 }
 
-inline uint16_t operator"" _u16(unsigned long long value) {
+inline uint16_t operator""_u16(unsigned long long value) {
   return static_cast<uint16_t>(value);
 }
 
-inline uint32_t operator"" _u32(unsigned long long value) {
+inline uint32_t operator""_u32(unsigned long long value) {
   return static_cast<uint32_t>(value);
 }
 
-inline uint64_t operator"" _u64(unsigned long long value) {
+inline uint64_t operator""_u64(unsigned long long value) {
   return static_cast<uint64_t>(value);
 }
 
-inline uint64_t operator"" _addr_t(unsigned long long value) {
+inline uint64_t operator""_addr_t(unsigned long long value) {
   return static_cast<addr_t>(value);
 }
 
 #if !defined(REMILL_DISABLE_INT128)
-inline uint128_t operator"" _u128(unsigned long long value) {
+inline uint128_t operator""_u128(unsigned long long value) {
   return static_cast<uint128_t>(value);
 }
 #endif
 
 
-inline int8_t operator"" _s8(unsigned long long value) {
+inline int8_t operator""_s8(unsigned long long value) {
   return static_cast<int8_t>(value);
 }
 
-inline int16_t operator"" _s16(unsigned long long value) {
+inline int16_t operator""_s16(unsigned long long value) {
   return static_cast<int16_t>(value);
 }
 
-inline int32_t operator"" _s32(unsigned long long value) {
+inline int32_t operator""_s32(unsigned long long value) {
   return static_cast<int32_t>(value);
 }
 
-inline int64_t operator"" _s64(unsigned long long value) {
+inline int64_t operator""_s64(unsigned long long value) {
   return static_cast<int64_t>(value);
 }
 
 #if !defined(REMILL_DISABLE_INT128)
-inline int128_t operator"" _s128(unsigned long long value) {
+inline int128_t operator""_s128(unsigned long long value) {
   return static_cast<int128_t>(value);
 }
 #endif


### PR DESCRIPTION
Ran into these issues when trying to use remill as a submodule in my template with `REMILL_ENABLE_TESTING=OFF` and a newer clang that spams warnings about this deprecated literal operator.