### PR TITLE
fix(deps): patch LLVM build for GCC 15 compatibility

### DIFF
--- a/dependencies/llvm.cmake
+++ b/dependencies/llvm.cmake
@@ -53,6 +53,8 @@ ExternalProject_Add(llvm
         ${LLVM_URL}
     URL_HASH
         "SHA256=${LLVM_SHA256}"
+    PATCH_COMMAND
+        ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/patches/patch_llvm_cstdint.cmake"
     CMAKE_CACHE_ARGS
         ${CMAKE_ARGS}
         ${LLVM_ARGS}

--- a/dependencies/patches/patch_llvm_cstdint.cmake
+++ b/dependencies/patches/patch_llvm_cstdint.cmake
@@ -1,0 +1,23 @@
+# patch_llvm_cstdint.cmake
+# Injected during LLVM extraction to fix GCC 15 compatibility
+
+set(TARGET_FILE "llvm/include/llvm/ADT/SmallVector.h")
+
+if(EXISTS "${TARGET_FILE}")
+  file(READ "${TARGET_FILE}" FILE_CONTENTS)
+
+  if(NOT FILE_CONTENTS MATCHES "#include <cstdint>")
+    message(STATUS "Patching ${TARGET_FILE} to include <cstdint>")
+    string(REPLACE
+      "#include <algorithm>"
+      "#include <cstdint>\n#include <algorithm>"
+      PATCHED_CONTENTS
+      "${FILE_CONTENTS}"
+    )
+    file(WRITE "${TARGET_FILE}" "${PATCHED_CONTENTS}")
+  else()
+    message(STATUS "${TARGET_FILE} is already patched.")
+  endif()
+else()
+  message(FATAL_ERROR "Could not find target file to patch: ${TARGET_FILE}")
+endif()

--- a/dependencies/patches/patch_llvm_cstdint.cmake
+++ b/dependencies/patches/patch_llvm_cstdint.cmake
@@ -1,23 +1,51 @@
 # patch_llvm_cstdint.cmake
 # Injected during LLVM extraction to fix GCC 15 compatibility
 
-set(TARGET_FILE "llvm/include/llvm/ADT/SmallVector.h")
+function(inject_cstdint TARGET_FILE INCLUDE_ANCHOR)
+  if(EXISTS "${TARGET_FILE}")
+    file(READ "${TARGET_FILE}" FILE_CONTENTS)
 
-if(EXISTS "${TARGET_FILE}")
-  file(READ "${TARGET_FILE}" FILE_CONTENTS)
+    if(NOT FILE_CONTENTS MATCHES "#include <cstdint>")
+      string(FIND "${FILE_CONTENTS}" "${INCLUDE_ANCHOR}" INCLUDE_ANCHOR_POS)
+      if(INCLUDE_ANCHOR_POS EQUAL -1)
+        message(FATAL_ERROR
+          "Could not find include anchor in ${TARGET_FILE}: ${INCLUDE_ANCHOR}"
+        )
+      endif()
 
-  if(NOT FILE_CONTENTS MATCHES "#include <cstdint>")
-    message(STATUS "Patching ${TARGET_FILE} to include <cstdint>")
-    string(REPLACE
-      "#include <algorithm>"
-      "#include <cstdint>\n#include <algorithm>"
-      PATCHED_CONTENTS
-      "${FILE_CONTENTS}"
-    )
-    file(WRITE "${TARGET_FILE}" "${PATCHED_CONTENTS}")
+      message(STATUS "Patching ${TARGET_FILE} to include <cstdint>")
+      string(REPLACE
+        "${INCLUDE_ANCHOR}"
+        "#include <cstdint>\n${INCLUDE_ANCHOR}"
+        PATCHED_CONTENTS
+        "${FILE_CONTENTS}"
+      )
+      file(WRITE "${TARGET_FILE}" "${PATCHED_CONTENTS}")
+    else()
+      message(STATUS "${TARGET_FILE} is already patched.")
+    endif()
   else()
-    message(STATUS "${TARGET_FILE} is already patched.")
+    message(FATAL_ERROR "Could not find target file to patch: ${TARGET_FILE}")
   endif()
-else()
-  message(FATAL_ERROR "Could not find target file to patch: ${TARGET_FILE}")
-endif()
+endfunction()
+
+inject_cstdint("llvm/include/llvm/ADT/SmallVector.h" "#include <algorithm>")
+
+foreach(TARGET_FILE IN ITEMS
+  "llvm/lib/Target/AArch64/MCTargetDesc/AArch64MCTargetDesc.h"
+  "llvm/lib/Target/AMDGPU/MCTargetDesc/AMDGPUMCTargetDesc.h"
+  "llvm/lib/Target/ARM/MCTargetDesc/ARMMCTargetDesc.h"
+  "llvm/lib/Target/AVR/MCTargetDesc/AVRMCTargetDesc.h"
+  "llvm/lib/Target/BPF/MCTargetDesc/BPFMCTargetDesc.h"
+  "llvm/lib/Target/LoongArch/MCTargetDesc/LoongArchMCTargetDesc.h"
+  "llvm/lib/Target/MSP430/MCTargetDesc/MSP430MCTargetDesc.h"
+  "llvm/lib/Target/PowerPC/MCTargetDesc/PPCMCTargetDesc.h"
+  "llvm/lib/Target/RISCV/MCTargetDesc/RISCVMCTargetDesc.h"
+  "llvm/lib/Target/Sparc/MCTargetDesc/SparcMCTargetDesc.h"
+  "llvm/lib/Target/SystemZ/MCTargetDesc/SystemZMCTargetDesc.h"
+  "llvm/lib/Target/VE/MCTargetDesc/VEMCTargetDesc.h"
+  "llvm/lib/Target/X86/MCTargetDesc/X86MCTargetDesc.h"
+  "llvm/lib/Target/Xtensa/MCTargetDesc/XtensaMCTargetDesc.h"
+)
+  inject_cstdint("${TARGET_FILE}" "#include <memory>")
+endforeach()


### PR DESCRIPTION
Fixes LLVM 17 compilation failures on GCC 15+ toolchains due to a missing `<cstdint>` include in `SmallVector.h` (`error: use of undeclared identifier 'uint64_t'`). Caused by [GCC 15 header dependency changes](https://gcc.gnu.org/gcc-15/porting_to.html#header-dep-changes) in `libstdc++`

Adds a CMake script and updates `dependencies/llvm.cmake` with a `PATCH_COMMAND` to inject `#include <cstdint>` into `SmallVector.h` during extraction.